### PR TITLE
[mkcal] Simplify rawExpandedEvents() by using upstrean OccurrenceIterator.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11.4)
 
 project(mkcal
-	VERSION 0.5.35
+	VERSION 0.5.45
 	DESCRIPTION "Mkcal calendar library")
 
 set(CMAKE_AUTOMOC ON)

--- a/rpm/mkcal-qt5.spec
+++ b/rpm/mkcal-qt5.spec
@@ -1,7 +1,7 @@
 Name:       mkcal-qt5
 
 Summary:    Extended KDE kcal calendar library port for Maemo
-Version:    0.5.41
+Version:    0.5.45
 Release:    1
 License:    LGPLv2+
 URL:        https://github.com/mer-packages/mkcal

--- a/src/extendedcalendar.h
+++ b/src/extendedcalendar.h
@@ -557,16 +557,6 @@ public:
                                             bool *expandLimitHit = 0);
 
     /**
-      Returns a list of expanded events that occur on dates between start and end inclusive.
-      @param startInclusive if true, only events that begin on or after start are included, otherwise
-             events that begin before start, but continue into start will also be included.
-      @param endInclusive if true, only events that end on or before end are included.
-    */
-    ExpandedIncidenceList rawExpandedEvents(const QDate &start, const QDate &end,
-                                            bool startInclusive = false, bool endInclusive = false,
-                                            const QTimeZone &timeZone = QTimeZone()) const;
-
-    /**
       Expand multiday incidences in a list.
 
       This call expands the multiday events within the given list so


### PR DESCRIPTION
This has the consequence that it's not mandatory anymore to declare any exception recurrenceId as an exdatetime of the parent. The API of rawExpandedEvents() is modified to simplify it. The inclusion parameters were not used. The expansion time zone has also been removed, so returned start time and end time are always given in the system time zone. This allow to transparently handle the events declared in local time.

@chriadam and @pvuorela, the purpose of this MR is to simplify a lot the rawExpandedEvents() by relying on the upstream OccurrenceIterator. It requires to change the method API though. When looking where it is used, I find only mer-core/nemo-qml-plugin-calendar in calendarworker.cpp. There it is used without the inclusive parameters, so I removed them. It is also used with the system time zone, which is in my opinion the only value that makes sense. Assuming only system time zone is used to expand the events simplify the routine a lot and avoid all changes in date time that were previously done.

I've slightly updated the tests to use the new API and all of them are passing (except the all day deserialisation onethat is broken, but not related), particularly, they are also passing when specifying another time zone like in TZ=Asia/Ho_Chi_Minh ./tst_storage.

If you agree with the API change, I'll submit a MR in the QML plugin to update it also.

The last advantage of this MR (besides relying more on upstream methods, and removing lines from mKCal) is also very important : it removes the necessity to add occurrence exception recurrenceId as exDateTime in the parent. This necessity was contrary to the RFC, but used as a mean to get timesInInterval() of the parent not to return an event on the exception date time (OccurrenceIterator is filtering out the returned list of timeInInterval for us and makes this all transparent). This RFC violation created complications in sync code that needs to add the exDateTime when receiving a recurring event with exceptions and remove them when upsyncing.

That's the purpose of the second commit : it is removing the addition of the exDateTime in dissociateSingleOccurrence(). But because of legacy events stored with additional exDateTime, not all code from the sync plugins handling with removing the additionnal exDateTime can be removed at this time.

Last comment maybe : one may decide to rename the rawExpandedEvents() to rawExpandedIncidences() since upstream OccurrenceIterator is dealing on events, todos and journals.

There is a long comment history, see : https://git.sailfishos.org/mer-core/mkcal/merge_requests/66