### PR TITLE
Build with timed-qt5 support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ set_target_properties(mkcal-qt5 PROPERTIES
 
 add_definitions(-fvisibility=hidden -fvisibility-inlines-hidden)
 add_definitions(-DMKCALPLUGINDIR="${CMAKE_INSTALL_LIBDIR}/mkcalplugins")
+add_definitions(-DTIMED_SUPPORT)
 
 # Install the library
 install(TARGETS mkcal-qt5

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(tst_storage
 	mkcal-qt5)
 
 add_test(tst_storage tst_storage)
+add_definitions(-DTIMED_SUPPORT)
 
 if(INSTALL_TESTS)
 	install(TARGETS tst_storage


### PR DESCRIPTION
Adds the `TIMED_SUPPORT` cmake flag which, when set, will in turn pass the `TIMED_SUPPORT` pre-processor define on to the compiler.

Updates the spec file to set the flag by default.

Fixes a regression introduced in d1bf0e9d25ab42e91fe70c8 that prevented alarms from working.