### PR TITLE
Cannot delete or add events under certain conditions

### DIFF
--- a/src/extendedcalendar.cpp
+++ b/src/extendedcalendar.cpp
@@ -41,6 +41,7 @@
 #include "logging_p.h"
 
 #include <KCalendarCore/CalFilter>
+#include <KCalendarCore/CalFormat>
 #include <KCalendarCore/Sorting>
 using namespace KCalendarCore;
 
@@ -310,7 +311,10 @@ bool ExtendedCalendar::addEvent(const Event::Ptr &aEvent, const QString &noteboo
         return false;
     }
 
-    if (MemoryCalendar::event(aEvent->uid(), aEvent->recurrenceId())) {
+    if (aEvent->uid().isEmpty()) {
+        qCWarning(lcMkcal) << "adding an event without uid, creating one.";
+        aEvent->setUid(CalFormat::createUniqueId());
+    } else if (MemoryCalendar::event(aEvent->uid(), aEvent->recurrenceId())) {
         qCDebug(lcMkcal) << "Duplicate found, event was not added";
         return false;
     }
@@ -350,13 +354,18 @@ bool ExtendedCalendar::addTodo(const Todo::Ptr &aTodo, const QString &notebookUi
         return false;
     }
 
-    Todo::Ptr old = MemoryCalendar::todo(aTodo->uid(), aTodo->recurrenceId());
-    if (old) {
-        if (aTodo->revision() > old->revision()) {
-            deleteTodo(old);   // move old to deleted
-        } else {
-            qCDebug(lcMkcal) << "Duplicate found, todo was not added";
-            return false;
+    if (aTodo->uid().isEmpty()) {
+        qCWarning(lcMkcal) << "adding a todo without uid, creating one.";
+        aTodo->setUid(CalFormat::createUniqueId());
+    } else {
+        Todo::Ptr old = MemoryCalendar::todo(aTodo->uid(), aTodo->recurrenceId());
+        if (old) {
+            if (aTodo->revision() > old->revision()) {
+                deleteTodo(old);   // move old to deleted
+            } else {
+                qCDebug(lcMkcal) << "Duplicate found, todo was not added";
+                return false;
+            }
         }
     }
 
@@ -597,13 +606,18 @@ bool ExtendedCalendar::addJournal(const Journal::Ptr &aJournal, const QString &n
         return false;
     }
 
-    Journal::Ptr old = journal(aJournal->uid(), aJournal->recurrenceId());
-    if (old) {
-        if (aJournal->revision() > old->revision()) {
-            deleteJournal(old);   // move old to deleted
-        } else {
-            qCDebug(lcMkcal) << "Duplicate found, journal was not added";
-            return false;
+    if (aJournal->uid().isEmpty()) {
+        qCWarning(lcMkcal) << "adding a journal without uid, creating one.";
+        aJournal->setUid(CalFormat::createUniqueId());
+    } else {
+        Journal::Ptr old = journal(aJournal->uid(), aJournal->recurrenceId());
+        if (old) {
+            if (aJournal->revision() > old->revision()) {
+                deleteJournal(old);   // move old to deleted
+            } else {
+                qCDebug(lcMkcal) << "Duplicate found, journal was not added";
+                return false;
+            }
         }
     }
 

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -1741,7 +1741,8 @@ bool SqliteStorage::Private::saveIncidences(QHash<QString, Incidence::Ptr> &list
 
     for (it = list.constBegin(); it != list.constEnd(); ++it) {
         QString notebookUid = mCalendar->notebook(*it);
-        if (!mStorage->isValidNotebook(notebookUid)) {
+        if ((dbop == DBInsert || dbop == DBUpdate)
+            && !mStorage->isValidNotebook(notebookUid)) {
             qCWarning(lcMkcal) << "invalid notebook - not saving incidence" << (*it)->uid();
             continue;
         } else {


### PR DESCRIPTION
Here are two commits fixing two separated issues :
- since we are now validating notebooks, it has created an issue when calling `ExtendedCalendar::deleteAllIncidences()`. This method is used nowhere except in the webcal plugin, I guess, so it has been unnoticed. This method is calling `Calendar::close()` to clear memory of all incidences and of all tables... But one table that is cleared, is the notebook association one (see `MemoryCalendar::close()`). So it's not possible anymore to call `Calendar::notebook(incidence)` after this, while the code actually deleting the incidence in sqlitestorage.cpp is checking that the incidences belong to a notebook... It is debatable to know if it's better not to kill the notebook association on call of `deleteAllIncidences()`, but it's actually difficult not to because the call is in KCalendarCore upstream. I'm proposing a much simpler fix, by actually ensuring the notebook validity on insertion and update only. Which is the purpose of validation after all : not to create in the DB an orphan event.
- some calendar web resources are broken by not providing a UID for every event. When parsing such resource with KCalendarCore::ICalFormat, it is creating incidences without UID (of course) and it is adding them in a calendar that uses the UID as a key to identify them. This results at the end with a calendar populated with only one incidence, because each addition during parsing is scratching the previous incidence referenced by an empty uid. KCalendarCore is actively not creating a fake UID for such events, see line 1902 in `icalformat_p.cpp`. So I'm a bit hopeless to make them change their mind. What I'm suggesting here is simply to ensure that a fake UID is created on calendar insertion when the calendar is an `ExtendedCalendar` from mKCal.

The two commits are fixing the holiday calendar I'm using, see https://fr.ftp.opendatasoft.com/openscol/fr-en-calendrier-scolaire/Zone-A.ics

About the second commit, one can argue that the resource is broken (which is the case, and I warned the provider), but the fact that we can add events without UID is not a good situation neither, thus the second commit.