### PR TITLE
Code cleanups. JB#52853

### DIFF
--- a/src/sqliteformat.cpp
+++ b/src/sqliteformat.cpp
@@ -1492,7 +1492,6 @@ int SqliteFormat::Private::selectRowId(Incidence::Ptr incidence)
     const char *query = NULL;
     int qsize = 0;
     sqlite3_stmt *stmt = NULL;
-    const char *tail = NULL;
 
     QByteArray u;
     qint64 secsRecurId;
@@ -1501,7 +1500,7 @@ int SqliteFormat::Private::selectRowId(Incidence::Ptr incidence)
     query = SELECT_ROWID_FROM_COMPONENTS_BY_UID_AND_RECURID;
     qsize = sizeof(SELECT_ROWID_FROM_COMPONENTS_BY_UID_AND_RECURID);
 
-    sqlite3_prepare_v2(mDatabase, query, qsize, &stmt, &tail);
+    sqlite3_prepare_v2(mDatabase, query, qsize, &stmt, NULL);
     u = incidence->uid().toUtf8();
     sqlite3_bind_text(stmt, index, u.constData(), u.length(), SQLITE_STATIC);
     if (incidence->recurrenceId().isValid()) {

--- a/src/sqliteformat.cpp
+++ b/src/sqliteformat.cpp
@@ -129,30 +129,30 @@ bool SqliteFormat::modifyCalendars(const Notebook::Ptr &notebook,
     sqlite3_int64  secs;
 
     if (dbop == DBInsert || dbop == DBDelete)
-        sqlite3_bind_text(stmt, index, uid, uid.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, uid, uid.length(), SQLITE_STATIC);
 
     if (dbop == DBInsert || dbop == DBUpdate) {
-        sqlite3_bind_text(stmt, index, name, name.length(), SQLITE_STATIC);
-        sqlite3_bind_text(stmt, index, description, description.length(), SQLITE_STATIC);
-        sqlite3_bind_text(stmt, index, color, color.length(), SQLITE_STATIC);
-        sqlite3_bind_int(stmt, index, notebook->flags());
+        SL3_bind_text(stmt, index, name, name.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, description, description.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, color, color.length(), SQLITE_STATIC);
+        SL3_bind_int(stmt, index, notebook->flags());
         secs = d->mStorage->toOriginTime(notebook->syncDate().toUTC());
-        sqlite3_bind_int64(stmt, index, secs);
-        sqlite3_bind_text(stmt, index, plugin, plugin.length(), SQLITE_STATIC);
-        sqlite3_bind_text(stmt, index, account, account.length(), SQLITE_STATIC);
-        sqlite3_bind_int64(stmt, index, notebook->attachmentSize());
+        SL3_bind_int64(stmt, index, secs);
+        SL3_bind_text(stmt, index, plugin, plugin.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, account, account.length(), SQLITE_STATIC);
+        SL3_bind_int64(stmt, index, notebook->attachmentSize());
         secs = d->mStorage->toOriginTime(notebook->modifiedDate().toUTC());
-        sqlite3_bind_int64(stmt, index, secs);
-        sqlite3_bind_text(stmt, index, sharedWith, sharedWith.length(), SQLITE_STATIC);
-        sqlite3_bind_text(stmt, index, syncProfile, syncProfile.length(), SQLITE_STATIC);
+        SL3_bind_int64(stmt, index, secs);
+        SL3_bind_text(stmt, index, sharedWith, sharedWith.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, syncProfile, syncProfile.length(), SQLITE_STATIC);
         secs = d->mStorage->toOriginTime(notebook->creationDate().toUTC());
-        sqlite3_bind_int64(stmt, index, secs);
+        SL3_bind_int64(stmt, index, secs);
 
         if (dbop == DBUpdate)
-            sqlite3_bind_text(stmt, index, uid, uid.length(), SQLITE_STATIC);
+            SL3_bind_text(stmt, index, uid, uid.length(), SQLITE_STATIC);
     }
 
-    sqlite3_step(stmt);
+    SL3_step(stmt);
 
     if (!d->modifyCalendarProperties(notebook, dbop)) {
         qCWarning(lcMkcal) << "failed to modify calendarproperties for notebook" << uid;
@@ -176,16 +176,16 @@ bool SqliteFormat::purgeDeletedComponents(const KCalendarCore::Incidence::Ptr &i
     qint64 secsRecurId = incidence->hasRecurrenceId()
         ? d->mStorage->toOriginTime(incidence->recurrenceId()) : 0;
 
-    sqlite3_bind_text(stmt1, index, u.constData(), u.length(), SQLITE_STATIC);
-    sqlite3_bind_int64(stmt1, index, secsRecurId);
+    SL3_bind_text(stmt1, index, u.constData(), u.length(), SQLITE_STATIC);
+    SL3_bind_int64(stmt1, index, secsRecurId);
 
-    sqlite3_step(stmt1);
+    SL3_step(stmt1);
     while (rv == SQLITE_ROW) {
         int rowid = sqlite3_column_int(stmt1, 0);
 
         int index2 = 1;
-        sqlite3_bind_int(stmt2, index2, rowid);
-        sqlite3_step(stmt2);
+        SL3_bind_int(stmt2, index2, rowid);
+        SL3_step(stmt2);
         sqlite3_reset(stmt2);
 
         if (!d->modifyCustomproperties(incidence, rowid, DBDelete, stmt3, NULL))
@@ -206,7 +206,7 @@ bool SqliteFormat::purgeDeletedComponents(const KCalendarCore::Incidence::Ptr &i
         if (!d->modifyAttachments(incidence, rowid, DBDelete, attachmentStmt, NULL))
             qCWarning(lcMkcal) << "failed to delete attachments for incidence" << u;
 
-        sqlite3_step(stmt1);
+        SL3_step(stmt1);
     }
 
     sqlite3_reset(stmt1);
@@ -224,26 +224,26 @@ static bool setDateTime(SqliteStorage *storage, sqlite3_stmt *stmt, int &index, 
 
     if (dateTime.isValid()) {
         secs = storage->toOriginTime(dateTime);
-        sqlite3_bind_int64(stmt, index, secs);
+        SL3_bind_int64(stmt, index, secs);
         secs = storage->toLocalOriginTime(dateTime);
-        sqlite3_bind_int64(stmt, index, secs);
+        SL3_bind_int64(stmt, index, secs);
         if (allDay) {
             tz = FLOATING_DATE;
         } else {
             tz = dateTime.timeZone().id();
         }
-        sqlite3_bind_text(stmt, index, tz.constData(), tz.length(), SQLITE_TRANSIENT);
+        SL3_bind_text(stmt, index, tz.constData(), tz.length(), SQLITE_TRANSIENT);
     } else {
-        sqlite3_bind_int(stmt, index, 0);
-        sqlite3_bind_int(stmt, index, 0);
-        sqlite3_bind_text(stmt, index, "", 0, SQLITE_STATIC);
+        SL3_bind_int(stmt, index, 0);
+        SL3_bind_int(stmt, index, 0);
+        SL3_bind_text(stmt, index, "", 0, SQLITE_STATIC);
     }
     return true;
  error:
     return false;
 }
 
-#define sqlite3_bind_date_time( storage, stmt, index, dt, allDay)      \
+#define SL3_bind_date_time( storage, stmt, index, dt, allDay)          \
     {                                                                  \
         if (!setDateTime(storage, stmt, index, dt, allDay))            \
             goto error;                                                \
@@ -285,18 +285,18 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
     }
 
     if (dbop == DBDelete) {
-        sqlite3_bind_int(stmt1, index, rowid);
+        SL3_bind_int(stmt1, index, rowid);
     }
 
     if (dbop == DBMarkDeleted) {
         secs = d->mStorage->toOriginTime(QDateTime::currentDateTimeUtc());
-        sqlite3_bind_int64(stmt1, index, secs);
-        sqlite3_bind_int(stmt1, index, rowid);
+        SL3_bind_int64(stmt1, index, secs);
+        SL3_bind_int(stmt1, index, rowid);
     }
 
     if (dbop == DBInsert || dbop == DBUpdate) {
         notebook = nbook.toUtf8();
-        sqlite3_bind_text(stmt1, index, notebook.constData(), notebook.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, notebook.constData(), notebook.length(), SQLITE_STATIC);
 
         switch (incidence->type()) {
         case Incidence::TypeEvent:
@@ -314,20 +314,20 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
         case Incidence::TypeUnknown:
             goto error;
         }
-        sqlite3_bind_text(stmt1, index, type.constData(), type.length(), SQLITE_STATIC);   // NOTE
+        SL3_bind_text(stmt1, index, type.constData(), type.length(), SQLITE_STATIC);   // NOTE
 
         summary = incidence->summary().toUtf8();
-        sqlite3_bind_text(stmt1, index, summary.constData(), summary.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, summary.constData(), summary.length(), SQLITE_STATIC);
 
         category = incidence->categoriesStr().toUtf8();
-        sqlite3_bind_text(stmt1, index, category.constData(), category.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, category.constData(), category.length(), SQLITE_STATIC);
 
         if ((incidence->type() == Incidence::TypeEvent) ||
                 (incidence->type() == Incidence::TypeJournal)) {
-            sqlite3_bind_date_time(d->mStorage, stmt1, index, incidence->dtStart(), incidence->allDay());
+            SL3_bind_date_time(d->mStorage, stmt1, index, incidence->dtStart(), incidence->allDay());
 
             // set HasDueDate to false
-            sqlite3_bind_int(stmt1, index, 0);
+            SL3_bind_int(stmt1, index, 0);
 
             QDateTime effectiveDtEnd;
             if (incidence->type() == Incidence::TypeEvent) {
@@ -342,103 +342,103 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
                     }
                 }
             }
-            sqlite3_bind_date_time(d->mStorage, stmt1, index, effectiveDtEnd, incidence->allDay());
+            SL3_bind_date_time(d->mStorage, stmt1, index, effectiveDtEnd, incidence->allDay());
         } else if (incidence->type() == Incidence::TypeTodo) {
             Todo::Ptr todo = incidence.staticCast<Todo>();
-            sqlite3_bind_date_time(d->mStorage, stmt1, index,
+            SL3_bind_date_time(d->mStorage, stmt1, index,
                                    todo->hasStartDate() ? todo->dtStart(true) : QDateTime(), todo->allDay());
 
-            sqlite3_bind_int(stmt1, index, (int) todo->hasDueDate());
+            SL3_bind_int(stmt1, index, (int) todo->hasDueDate());
 
-            sqlite3_bind_date_time(d->mStorage, stmt1, index, todo->hasDueDate() ? todo->dtDue(true) : QDateTime(), todo->allDay());
+            SL3_bind_date_time(d->mStorage, stmt1, index, todo->hasDueDate() ? todo->dtDue(true) : QDateTime(), todo->allDay());
         }
 
         if (incidence->type() != Incidence::TypeJournal) {
-            sqlite3_bind_int(stmt1, index, incidence->duration().asSeconds()); // NOTE
+            SL3_bind_int(stmt1, index, incidence->duration().asSeconds()); // NOTE
         } else {
-            sqlite3_bind_int(stmt1, index, 0);
+            SL3_bind_int(stmt1, index, 0);
         }
 
-        sqlite3_bind_int(stmt1, index, incidence->secrecy()); // NOTE
+        SL3_bind_int(stmt1, index, incidence->secrecy()); // NOTE
 
         if (incidence->type() != Incidence::TypeJournal) {
             location = incidence->location().toUtf8();
-            sqlite3_bind_text(stmt1, index, location.constData(), location.length(), SQLITE_STATIC);
+            SL3_bind_text(stmt1, index, location.constData(), location.length(), SQLITE_STATIC);
         } else {
-            sqlite3_bind_text(stmt1, index, "", 0, SQLITE_STATIC);
+            SL3_bind_text(stmt1, index, "", 0, SQLITE_STATIC);
         }
 
         description = incidence->description().toUtf8();
-        sqlite3_bind_text(stmt1, index, description.constData(), description.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, description.constData(), description.length(), SQLITE_STATIC);
 
-        sqlite3_bind_int(stmt1, index, incidence->status()); // NOTE
+        SL3_bind_int(stmt1, index, incidence->status()); // NOTE
 
         if (incidence->type() != Incidence::TypeJournal) {
             if (incidence->hasGeo()) {
-                sqlite3_bind_double(stmt1, index, incidence->geoLatitude());
-                sqlite3_bind_double(stmt1, index, incidence->geoLongitude());
+                SL3_bind_double(stmt1, index, incidence->geoLatitude());
+                SL3_bind_double(stmt1, index, incidence->geoLongitude());
             } else {
-                sqlite3_bind_double(stmt1, index, INVALID_LATLON);
-                sqlite3_bind_double(stmt1, index, INVALID_LATLON);
+                SL3_bind_double(stmt1, index, INVALID_LATLON);
+                SL3_bind_double(stmt1, index, INVALID_LATLON);
             }
 
-            sqlite3_bind_int(stmt1, index, incidence->priority());
+            SL3_bind_int(stmt1, index, incidence->priority());
 
             resources = incidence->resources().join(" ").toUtf8();
-            sqlite3_bind_text(stmt1, index, resources.constData(), resources.length(), SQLITE_STATIC);
+            SL3_bind_text(stmt1, index, resources.constData(), resources.length(), SQLITE_STATIC);
         } else {
-            sqlite3_bind_double(stmt1, index, INVALID_LATLON);
-            sqlite3_bind_double(stmt1, index, INVALID_LATLON);
-            sqlite3_bind_int(stmt1, index, 0);
-            sqlite3_bind_text(stmt1, index, "", 0, SQLITE_STATIC);
+            SL3_bind_double(stmt1, index, INVALID_LATLON);
+            SL3_bind_double(stmt1, index, INVALID_LATLON);
+            SL3_bind_int(stmt1, index, 0);
+            SL3_bind_text(stmt1, index, "", 0, SQLITE_STATIC);
         }
 
         if (dbop == DBInsert && incidence->created().isNull())
             incidence->setCreated(QDateTime::currentDateTimeUtc());
         secs = d->mStorage->toOriginTime(incidence->created());
-        sqlite3_bind_int64(stmt1, index, secs);
+        SL3_bind_int64(stmt1, index, secs);
 
         secs = d->mStorage->toOriginTime(QDateTime::currentDateTimeUtc());
-        sqlite3_bind_int64(stmt1, index, secs);   // datestamp
+        SL3_bind_int64(stmt1, index, secs);   // datestamp
 
         secs = d->mStorage->toOriginTime(incidence->lastModified());
-        sqlite3_bind_int64(stmt1, index, secs);
+        SL3_bind_int64(stmt1, index, secs);
 
-        sqlite3_bind_int(stmt1, index, incidence->revision());
+        SL3_bind_int(stmt1, index, incidence->revision());
 
         comments = incidence->comments().join(" ").toUtf8();
-        sqlite3_bind_text(stmt1, index, comments.constData(), comments.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, comments.constData(), comments.length(), SQLITE_STATIC);
 
         // Attachments are now stored in a dedicated table.
-        sqlite3_bind_text(stmt1, index, nullptr, 0, SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, nullptr, 0, SQLITE_STATIC);
 
         contact = incidence->contacts().join(" ").toUtf8();
-        sqlite3_bind_text(stmt1, index, contact.constData(), contact.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, contact.constData(), contact.length(), SQLITE_STATIC);
 
-        sqlite3_bind_int(stmt1, index, 0);      //Invitation status removed. Needed? FIXME
+        SL3_bind_int(stmt1, index, 0);      //Invitation status removed. Needed? FIXME
 
         // Never save recurrenceId as FLOATING_DATE, because the time of a
         // floating date is not guaranteed on read and recurrenceId is used
         // for date-time comparisons.
-        sqlite3_bind_date_time(d->mStorage, stmt1, index, incidence->recurrenceId(), false);
+        SL3_bind_date_time(d->mStorage, stmt1, index, incidence->recurrenceId(), false);
 
         relatedtouid = incidence->relatedTo().toUtf8();
-        sqlite3_bind_text(stmt1, index, relatedtouid.constData(), relatedtouid.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, relatedtouid.constData(), relatedtouid.length(), SQLITE_STATIC);
 
         url = incidence->url().toString().toUtf8();
-        sqlite3_bind_text(stmt1, index, url.constData(), url.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, url.constData(), url.length(), SQLITE_STATIC);
 
         uid = incidence->uid().toUtf8();
-        sqlite3_bind_text(stmt1, index, uid.constData(), uid.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, uid.constData(), uid.length(), SQLITE_STATIC);
 
         if (incidence->type() == Incidence::TypeEvent) {
             Event::Ptr event = incidence.staticCast<Event>();
-            sqlite3_bind_int(stmt1, index, (int)event->transparency());
+            SL3_bind_int(stmt1, index, (int)event->transparency());
         } else {
-            sqlite3_bind_int(stmt1, index, 0);
+            SL3_bind_int(stmt1, index, 0);
         }
 
-        sqlite3_bind_int(stmt1, index, (int) incidence->localOnly());
+        SL3_bind_int(stmt1, index, (int) incidence->localOnly());
 
         int percentComplete = 0;
         QDateTime effectiveDtCompleted;
@@ -454,17 +454,17 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
                 effectiveDtCompleted = todo->completed();
             }
         }
-        sqlite3_bind_int(stmt1, index, percentComplete);
-        sqlite3_bind_date_time(d->mStorage, stmt1, index, effectiveDtCompleted, incidence->allDay());
+        SL3_bind_int(stmt1, index, percentComplete);
+        SL3_bind_date_time(d->mStorage, stmt1, index, effectiveDtCompleted, incidence->allDay());
 
         colorstr = incidence->color().toUtf8();
-        sqlite3_bind_text(stmt1, index, colorstr.constData(), colorstr.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, colorstr.constData(), colorstr.length(), SQLITE_STATIC);
 
         if (dbop == DBUpdate)
-            sqlite3_bind_int(stmt1, index, rowid);
+            SL3_bind_int(stmt1, index, rowid);
     }
 
-    sqlite3_step(stmt1);
+    SL3_step(stmt1);
 
     if (dbop == DBInsert)
         rowid = sqlite3_last_insert_rowid(d->mDatabase);
@@ -535,18 +535,18 @@ bool SqliteFormat::Private::modifyCustomproperty(int rowid, const QByteArray &ke
     QByteArray parametersba;
 
     if (dbop == DBInsert || dbop == DBDelete)
-        sqlite3_bind_int(stmt, index, rowid);
+        SL3_bind_int(stmt, index, rowid);
 
     if (dbop == DBInsert) {
-        sqlite3_bind_text(stmt, index, key.constData(), key.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, key.constData(), key.length(), SQLITE_STATIC);
         valueba = value.toUtf8();
-        sqlite3_bind_text(stmt, index, valueba.constData(), valueba.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, valueba.constData(), valueba.length(), SQLITE_STATIC);
 
         parametersba = parameters.toUtf8();
-        sqlite3_bind_text(stmt, index, parametersba.constData(), parametersba.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, parametersba.constData(), parametersba.length(), SQLITE_STATIC);
     }
 
-    sqlite3_step(stmt);
+    SL3_step(stmt);
     success = true;
 
 error:
@@ -631,14 +631,14 @@ bool SqliteFormat::Private::modifyRdate(int rowid, int type, const QDateTime &da
     bool success = false;
 
     if (dbop == DBInsert || dbop == DBDelete)
-        sqlite3_bind_int(stmt, index, rowid);
+        SL3_bind_int(stmt, index, rowid);
 
     if (dbop == DBInsert) {
-        sqlite3_bind_int(stmt, index, type);
-        sqlite3_bind_date_time(mStorage, stmt, index, date, allDay);
+        SL3_bind_int(stmt, index, type);
+        SL3_bind_date_time(mStorage, stmt, index, date, allDay);
     }
 
-    sqlite3_step(stmt);
+    SL3_step(stmt);
     success = true;
 
 error:
@@ -689,7 +689,7 @@ bool SqliteFormat::Private::modifyAlarm(int rowid, Alarm::Ptr alarm,
     QByteArray properties;
 
     if (dbop == DBInsert || dbop == DBDelete)
-        sqlite3_bind_int(stmt, index, rowid);
+        SL3_bind_int(stmt, index, rowid);
 
     if (dbop == DBInsert) {
         int action = 0; // default Alarm::Invalid
@@ -728,40 +728,40 @@ bool SqliteFormat::Private::modifyAlarm(int rowid, Alarm::Ptr alarm,
             break;
         }
 
-        sqlite3_bind_int(stmt, index, action);
+        SL3_bind_int(stmt, index, action);
 
         if (alarm->repeatCount()) {
-            sqlite3_bind_int(stmt, index, alarm->repeatCount());
-            sqlite3_bind_int(stmt, index, alarm->snoozeTime().asSeconds());
+            SL3_bind_int(stmt, index, alarm->repeatCount());
+            SL3_bind_int(stmt, index, alarm->snoozeTime().asSeconds());
         } else {
-            sqlite3_bind_int(stmt, index, 0);
-            sqlite3_bind_int(stmt, index, 0);
+            SL3_bind_int(stmt, index, 0);
+            SL3_bind_int(stmt, index, 0);
         }
 
         if (alarm->hasStartOffset()) {
-            sqlite3_bind_int(stmt, index, alarm->startOffset().asSeconds());
+            SL3_bind_int(stmt, index, alarm->startOffset().asSeconds());
             relation = QString("startTriggerRelation").toUtf8();
-            sqlite3_bind_text(stmt, index, relation.constData(), relation.length(), SQLITE_STATIC);
-            sqlite3_bind_int(stmt, index, 0); // time
-            sqlite3_bind_int(stmt, index, 0); // localtime
-            sqlite3_bind_text(stmt, index, "", 0, SQLITE_STATIC);
+            SL3_bind_text(stmt, index, relation.constData(), relation.length(), SQLITE_STATIC);
+            SL3_bind_int(stmt, index, 0); // time
+            SL3_bind_int(stmt, index, 0); // localtime
+            SL3_bind_text(stmt, index, "", 0, SQLITE_STATIC);
         } else if (alarm->hasEndOffset()) {
-            sqlite3_bind_int(stmt, index, alarm->endOffset().asSeconds());
+            SL3_bind_int(stmt, index, alarm->endOffset().asSeconds());
             relation = QString("endTriggerRelation").toUtf8();
-            sqlite3_bind_text(stmt, index, relation.constData(), relation.length(), SQLITE_STATIC);
-            sqlite3_bind_int(stmt, index, 0); // time
-            sqlite3_bind_int(stmt, index, 0); // localtime
-            sqlite3_bind_text(stmt, index, "", 0, SQLITE_STATIC);
+            SL3_bind_text(stmt, index, relation.constData(), relation.length(), SQLITE_STATIC);
+            SL3_bind_int(stmt, index, 0); // time
+            SL3_bind_int(stmt, index, 0); // localtime
+            SL3_bind_text(stmt, index, "", 0, SQLITE_STATIC);
         } else {
-            sqlite3_bind_int(stmt, index, 0); // offset
-            sqlite3_bind_text(stmt, index, "", 0, SQLITE_STATIC); // relation
-            sqlite3_bind_date_time(mStorage, stmt, index, alarm->time(), false);
+            SL3_bind_int(stmt, index, 0); // offset
+            SL3_bind_text(stmt, index, "", 0, SQLITE_STATIC); // relation
+            SL3_bind_date_time(mStorage, stmt, index, alarm->time(), false);
         }
 
-        sqlite3_bind_text(stmt, index, description.constData(), description.length(), SQLITE_STATIC);
-        sqlite3_bind_text(stmt, index, attachment.constData(), attachment.length(), SQLITE_STATIC);
-        sqlite3_bind_text(stmt, index, summary.constData(), summary.length(), SQLITE_STATIC);
-        sqlite3_bind_text(stmt, index, addresses.constData(), addresses.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, description.constData(), description.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, attachment.constData(), attachment.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, summary.constData(), summary.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, addresses.constData(), addresses.length(), SQLITE_STATIC);
 
         QStringList list;
         const QMap<QByteArray, QString> custom = alarm->customProperties();
@@ -772,11 +772,11 @@ bool SqliteFormat::Private::modifyAlarm(int rowid, Alarm::Ptr alarm,
         if (!list.isEmpty())
             properties = list.join("\r\n").toUtf8();
 
-        sqlite3_bind_text(stmt, index, properties.constData(), properties.length(), SQLITE_STATIC);
-        sqlite3_bind_int(stmt, index, (int)alarm->enabled());
+        SL3_bind_text(stmt, index, properties.constData(), properties.length(), SQLITE_STATIC);
+        SL3_bind_int(stmt, index, (int)alarm->enabled());
     }
 
-    sqlite3_step(stmt);
+    SL3_step(stmt);
     success = true;
 
 error:
@@ -839,18 +839,18 @@ bool SqliteFormat::Private::modifyRecursive(int rowid, RecurrenceRule *rule, DBO
     QByteArray bySetPos;
 
     if (dbop == DBInsert || dbop == DBDelete)
-        sqlite3_bind_int(stmt, index, rowid);
+        SL3_bind_int(stmt, index, rowid);
 
     if (dbop == DBInsert) {
-        sqlite3_bind_int(stmt, index, type);
+        SL3_bind_int(stmt, index, type);
 
-        sqlite3_bind_int(stmt, index, (int)rule->recurrenceType()); // frequency
+        SL3_bind_int(stmt, index, (int)rule->recurrenceType()); // frequency
 
-        sqlite3_bind_date_time(mStorage, stmt, index, rule->endDt(), rule->allDay());
+        SL3_bind_date_time(mStorage, stmt, index, rule->endDt(), rule->allDay());
 
-        sqlite3_bind_int(stmt, index, rule->duration());  // count
+        SL3_bind_int(stmt, index, rule->duration());  // count
 
-        sqlite3_bind_int(stmt, index, (int)rule->frequency()); // interval
+        SL3_bind_int(stmt, index, (int)rule->frequency()); // interval
 
         QString number;
         QStringList byL;
@@ -865,7 +865,7 @@ bool SqliteFormat::Private::modifyRecursive(int rowid, RecurrenceRule *rule, DBO
       byL << number;                            \
     }                                   \
     listname = byL.join(" ").toUtf8();                  \
-    sqlite3_bind_text(stmt, index, listname.constData(), listname.length(), SQLITE_STATIC);
+    SL3_bind_text(stmt, index, listname.constData(), listname.length(), SQLITE_STATIC);
 
         // BYSECOND, MINUTE and HOUR, MONTHDAY, YEARDAY, WEEKNUMBER, MONTH
         // and SETPOS are standard int lists, so we can treat them with the
@@ -883,7 +883,7 @@ bool SqliteFormat::Private::modifyRecursive(int rowid, RecurrenceRule *rule, DBO
             byL << number;
         }
         byDays =  byL.join(" ").toUtf8();
-        sqlite3_bind_text(stmt, index, byDays.constData(), byDays.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, byDays.constData(), byDays.length(), SQLITE_STATIC);
 
         byL.clear();
         for (j = wdList.begin(); j != wdList.end(); ++j) {
@@ -891,7 +891,7 @@ bool SqliteFormat::Private::modifyRecursive(int rowid, RecurrenceRule *rule, DBO
             byL << number;
         }
         byDayPoss =  byL.join(" ").toUtf8();
-        sqlite3_bind_text(stmt, index, byDayPoss.constData(), byDayPoss.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, byDayPoss.constData(), byDayPoss.length(), SQLITE_STATIC);
 
         writeSetByList(byMonthDays);
         writeSetByList(byYearDays);
@@ -901,10 +901,10 @@ bool SqliteFormat::Private::modifyRecursive(int rowid, RecurrenceRule *rule, DBO
 
 #undef writeSetByList
 
-        sqlite3_bind_int(stmt, index, rule->weekStart());
+        SL3_bind_int(stmt, index, rule->weekStart());
     }
 
-    sqlite3_step(stmt);
+    SL3_step(stmt);
     success = true;
 
 error:
@@ -972,31 +972,31 @@ bool SqliteFormat::Private::modifyAttendee(int rowid, const Attendee &attendee, 
     QByteArray delegator;
 
     if (dbop == DBInsert || dbop == DBDelete)
-        sqlite3_bind_int(stmt, index, rowid);
+        SL3_bind_int(stmt, index, rowid);
 
     if (dbop == DBInsert) {
         email = attendee.email().toUtf8();
-        sqlite3_bind_text(stmt, index, email.constData(), email.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, email.constData(), email.length(), SQLITE_STATIC);
 
         name = attendee.name().toUtf8();
-        sqlite3_bind_text(stmt, index, name.constData(), name.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, name.constData(), name.length(), SQLITE_STATIC);
 
-        sqlite3_bind_int(stmt, index, (int)isOrganizer);
+        SL3_bind_int(stmt, index, (int)isOrganizer);
 
-        sqlite3_bind_int(stmt, index, (int)attendee.role());
+        SL3_bind_int(stmt, index, (int)attendee.role());
 
-        sqlite3_bind_int(stmt, index, (int)attendee.status());
+        SL3_bind_int(stmt, index, (int)attendee.status());
 
-        sqlite3_bind_int(stmt, index, (int)attendee.RSVP());
+        SL3_bind_int(stmt, index, (int)attendee.RSVP());
 
         delegate = attendee.delegate().toUtf8();
-        sqlite3_bind_text(stmt, index, delegate.constData(), delegate.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, delegate.constData(), delegate.length(), SQLITE_STATIC);
 
         delegator = attendee.delegator().toUtf8();
-        sqlite3_bind_text(stmt, index, delegator.constData(), delegator.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt, index, delegator.constData(), delegator.length(), SQLITE_STATIC);
     }
 
-    sqlite3_step(stmt);
+    SL3_step(stmt);
     success = true;
 
 error:
@@ -1020,8 +1020,8 @@ bool SqliteFormat::Private::modifyAttachments(Incidence::Ptr incidence,
         int index = 1;
         // In Update always delete all first then insert all
         // In Delete delete with uid at once
-        sqlite3_bind_int(deleteStatement, index, rowid);
-        sqlite3_step(deleteStatement);
+        SL3_bind_int(deleteStatement, index, rowid);
+        SL3_step(deleteStatement);
         sqlite3_reset(deleteStatement);
     }
 
@@ -1032,24 +1032,24 @@ bool SqliteFormat::Private::modifyAttachments(Incidence::Ptr incidence,
             int rv = 0;
             int index = 1;
 
-            sqlite3_bind_int(insertStatement, index, rowid);
+            SL3_bind_int(insertStatement, index, rowid);
             if (it->isBinary()) {
-                sqlite3_bind_blob(insertStatement, index, it->decodedData().constData(), it->size(), SQLITE_STATIC);
-                sqlite3_bind_text(insertStatement, index, nullptr, 0, SQLITE_STATIC);
+                SL3_bind_blob(insertStatement, index, it->decodedData().constData(), it->size(), SQLITE_STATIC);
+                SL3_bind_text(insertStatement, index, nullptr, 0, SQLITE_STATIC);
             } else if (it->isUri()) {
                 const QByteArray uri = it->uri().toUtf8();
-                sqlite3_bind_blob(insertStatement, index, nullptr, 0, SQLITE_STATIC);
-                sqlite3_bind_text(insertStatement, index, uri.constData(), uri.length(), SQLITE_STATIC);
+                SL3_bind_blob(insertStatement, index, nullptr, 0, SQLITE_STATIC);
+                SL3_bind_text(insertStatement, index, uri.constData(), uri.length(), SQLITE_STATIC);
             } else {
                 continue;
             }
             const QByteArray mime = it->mimeType().toUtf8();
-            sqlite3_bind_text(insertStatement, index, mime.constData(), mime.length(), SQLITE_STATIC);
-            sqlite3_bind_int(insertStatement, index, (it->showInline() ? 1 : 0));
+            SL3_bind_text(insertStatement, index, mime.constData(), mime.length(), SQLITE_STATIC);
+            SL3_bind_int(insertStatement, index, (it->showInline() ? 1 : 0));
             const QByteArray label = it->label().toUtf8();
-            sqlite3_bind_text(insertStatement, index, label.constData(), label.length(), SQLITE_STATIC);
-            sqlite3_bind_int(insertStatement, index, (it->isLocal() ? 1 : 0));
-            sqlite3_step(insertStatement);
+            SL3_bind_text(insertStatement, index, label.constData(), label.length(), SQLITE_STATIC);
+            SL3_bind_int(insertStatement, index, (it->isLocal() ? 1 : 0));
+            SL3_step(insertStatement);
             sqlite3_reset(insertStatement);
         }
     }
@@ -1104,9 +1104,9 @@ bool SqliteFormat::Private::deleteCalendarProperties(const QByteArray &id)
     int qsize = sizeof(DELETE_CALENDARPROPERTIES);
     sqlite3_stmt *stmt = NULL;
 
-    sqlite3_prepare_v2(mDatabase, query, qsize, &stmt, NULL);
-    sqlite3_bind_text(stmt, index, id.constData(), id.length(), SQLITE_STATIC);
-    sqlite3_step(stmt);
+    SL3_prepare_v2(mDatabase, query, qsize, &stmt, NULL);
+    SL3_bind_text(stmt, index, id.constData(), id.length(), SQLITE_STATIC);
+    SL3_step(stmt);
     success = true;
 
 error:
@@ -1126,13 +1126,13 @@ bool SqliteFormat::Private::insertCalendarProperty(const QByteArray &id,
     if (!mInsertCalProps) {
         const char *query = INSERT_CALENDARPROPERTIES;
         int qsize = sizeof(INSERT_CALENDARPROPERTIES);
-        sqlite3_prepare_v2(mDatabase, query, qsize, &mInsertCalProps, NULL);
+        SL3_prepare_v2(mDatabase, query, qsize, &mInsertCalProps, NULL);
     }
 
-    sqlite3_bind_text(mInsertCalProps, index, id.constData(), id.length(), SQLITE_STATIC);
-    sqlite3_bind_text(mInsertCalProps, index, key.constData(), key.length(), SQLITE_STATIC);
-    sqlite3_bind_text(mInsertCalProps, index, value.constData(), value.length(), SQLITE_STATIC);
-    sqlite3_step(mInsertCalProps);
+    SL3_bind_text(mInsertCalProps, index, id.constData(), id.length(), SQLITE_STATIC);
+    SL3_bind_text(mInsertCalProps, index, key.constData(), key.length(), SQLITE_STATIC);
+    SL3_bind_text(mInsertCalProps, index, value.constData(), value.length(), SQLITE_STATIC);
+    SL3_step(mInsertCalProps);
     success = true;
 
 error:
@@ -1151,7 +1151,7 @@ Notebook::Ptr SqliteFormat::selectCalendars(sqlite3_stmt *stmt)
     QDateTime modifiedDate = QDateTime();
     QDateTime creationDate = QDateTime();
 
-    sqlite3_step(stmt);
+    SL3_step(stmt);
 
     if (rv == SQLITE_ROW) {
         QString id = QString::fromUtf8((const char *)sqlite3_column_text(stmt, 0));
@@ -1256,7 +1256,7 @@ Incidence::Ptr SqliteFormat::selectComponents(sqlite3_stmt *stmt1, sqlite3_stmt 
     QString timezone;
     int rowid;
 
-    sqlite3_step(stmt1);
+    SL3_step(stmt1);
 
     if (rv == SQLITE_ROW) {
 
@@ -1500,17 +1500,17 @@ int SqliteFormat::Private::selectRowId(Incidence::Ptr incidence)
     query = SELECT_ROWID_FROM_COMPONENTS_BY_UID_AND_RECURID;
     qsize = sizeof(SELECT_ROWID_FROM_COMPONENTS_BY_UID_AND_RECURID);
 
-    sqlite3_prepare_v2(mDatabase, query, qsize, &stmt, NULL);
+    SL3_prepare_v2(mDatabase, query, qsize, &stmt, NULL);
     u = incidence->uid().toUtf8();
-    sqlite3_bind_text(stmt, index, u.constData(), u.length(), SQLITE_STATIC);
+    SL3_bind_text(stmt, index, u.constData(), u.length(), SQLITE_STATIC);
     if (incidence->recurrenceId().isValid()) {
         secsRecurId = mStorage->toOriginTime(incidence->recurrenceId());
-        sqlite3_bind_int64(stmt, index, secsRecurId);
+        SL3_bind_int64(stmt, index, secsRecurId);
     } else {
-        sqlite3_bind_int64(stmt, index, 0);
+        SL3_bind_int64(stmt, index, 0);
     }
 
-    sqlite3_step(stmt);
+    SL3_step(stmt);
 
     if (rv == SQLITE_ROW) {
         rowid = sqlite3_column_int(stmt, 0);
@@ -1530,12 +1530,12 @@ bool SqliteFormat::Private::selectCustomproperties(Incidence::Ptr incidence, int
     int index = 1;
     QMap<QByteArray, QString> map;
 
-    sqlite3_bind_int(stmt, index, rowid);
+    SL3_bind_int(stmt, index, rowid);
 
     map.clear();
 
     do {
-        sqlite3_step(stmt);
+        SL3_step(stmt);
 
         if (rv == SQLITE_ROW) {
             // Set Incidence data customproperties
@@ -1561,10 +1561,10 @@ bool SqliteFormat::Private::selectRdates(Incidence::Ptr incidence, int rowid, sq
     QString   timezone;
     QDateTime kdt;
 
-    sqlite3_bind_int(stmt, index, rowid);
+    SL3_bind_int(stmt, index, rowid);
 
     do {
-        sqlite3_step(stmt);
+        SL3_step(stmt);
 
         if (rv == SQLITE_ROW) {
             // Set Incidence data rdates
@@ -1602,10 +1602,10 @@ bool SqliteFormat::Private::selectRecursives(Incidence::Ptr incidence, int rowid
     QDateTime kdt;
     QDateTime dt;
 
-    sqlite3_bind_int(stmt, index, rowid);
+    SL3_bind_int(stmt, index, rowid);
 
     do {
-        sqlite3_step(stmt);
+        SL3_step(stmt);
 
         if (rv == SQLITE_ROW) {
             // Set Incidence data from recursive
@@ -1756,10 +1756,10 @@ bool SqliteFormat::Private::selectAlarms(Incidence::Ptr incidence, int rowid, sq
     QDateTime kdt;
     QDateTime dt;
 
-    sqlite3_bind_int(stmt, index, rowid);
+    SL3_bind_int(stmt, index, rowid);
 
     do {
-        sqlite3_step(stmt);
+        SL3_step(stmt);
 
         if (rv == SQLITE_ROW) {
             // Set Incidence data from alarm
@@ -1881,10 +1881,10 @@ bool SqliteFormat::Private::selectAttendees(Incidence::Ptr incidence, int rowid,
     int rv = 0;
     int index = 1;
 
-    sqlite3_bind_int(stmt, index, rowid);
+    SL3_bind_int(stmt, index, rowid);
 
     do {
-        sqlite3_step(stmt);
+        SL3_step(stmt);
 
         if (rv == SQLITE_ROW) {
             QString email = QString::fromUtf8((const char *)sqlite3_column_text(stmt, 1));
@@ -1914,10 +1914,10 @@ bool SqliteFormat::Private::selectAttachments(Incidence::Ptr incidence, int rowi
     int rv = 0;
     int index = 1;
 
-    sqlite3_bind_int(stmt, index, rowid);
+    SL3_bind_int(stmt, index, rowid);
 
     do {
-        sqlite3_step(stmt);
+        SL3_step(stmt);
 
         if (rv == SQLITE_ROW) {
             Attachment attach;
@@ -1957,7 +1957,7 @@ Person::List SqliteFormat::selectContacts(sqlite3_stmt *stmt)
     QHash<QString, Person> hash;
 
     do {
-        sqlite3_step(stmt);
+        SL3_step(stmt);
 
         if (rv == SQLITE_ROW) {
             QString name = QString::fromUtf8((const char *)sqlite3_column_text(stmt, 1));
@@ -1983,12 +1983,12 @@ bool SqliteFormat::Private::selectCalendarProperties(Notebook::Ptr notebook)
     if (!mSelectCalProps) {
         const char *query = SELECT_CALENDARPROPERTIES_BY_ID;
         int qsize = sizeof(SELECT_CALENDARPROPERTIES_BY_ID);
-        sqlite3_prepare_v2(mDatabase, query, qsize, &mSelectCalProps, NULL);
+        SL3_prepare_v2(mDatabase, query, qsize, &mSelectCalProps, NULL);
     }
 
-    sqlite3_bind_text(mSelectCalProps, index, id.constData(), id.length(), SQLITE_STATIC);
+    SL3_bind_text(mSelectCalProps, index, id.constData(), id.length(), SQLITE_STATIC);
     do {
-        sqlite3_step(mSelectCalProps);
+        SL3_step(mSelectCalProps);
         if (rv == SQLITE_ROW) {
             const QByteArray name = (const char *)sqlite3_column_text(mSelectCalProps, 1);
             const QString value = QString::fromUtf8((const char *)sqlite3_column_text(mSelectCalProps, 2));

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -189,77 +189,77 @@ bool SqliteStorage::open()
 
     /* Create Calendars, Components, etc. tables */
     query = CREATE_VERSION;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = CREATE_TIMEZONES;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
     // Create a global empty entry.
     query = INSERT_TIMEZONES;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = CREATE_CALENDARS;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = CREATE_COMPONENTS;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = CREATE_RDATES;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = CREATE_CUSTOMPROPERTIES;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = CREATE_RECURSIVE;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = CREATE_ALARM;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = CREATE_ATTENDEE;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = CREATE_ATTACHMENTS;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = CREATE_CALENDARPROPERTIES;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     /* Create index on frequently used columns */
     query = INDEX_CALENDAR;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = INDEX_COMPONENT;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = INDEX_COMPONENT_UID;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = INDEX_COMPONENT_NOTEBOOK;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = INDEX_RDATES;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = INDEX_CUSTOMPROPERTIES;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = INDEX_RECURSIVE;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = INDEX_ALARM;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = INDEX_ATTENDEE;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = INDEX_ATTACHMENTS;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = INDEX_CALENDARPROPERTIES;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     query = "PRAGMA foreign_keys = ON";
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
     if (!d->mChanged.open(QIODevice::Append)) {
         qCWarning(lcMkcal) << "cannot open changed file for" << d->mDatabaseName;
@@ -325,7 +325,7 @@ bool SqliteStorage::load()
     query1 = SELECT_COMPONENTS_ALL;
     qsize1 = sizeof(SELECT_COMPONENTS_ALL);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -357,18 +357,18 @@ bool SqliteStorage::load(const QString &uid, const QDateTime &recurrenceId)
         query1 = SELECT_COMPONENTS_BY_UID_AND_RECURID;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_UID_AND_RECURID);
 
-        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+        SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
         u = uid.toUtf8();
-        sqlite3_bind_text(stmt1, index, u.constData(), u.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, u.constData(), u.length(), SQLITE_STATIC);
         if (recurrenceId.isValid()) {
             secsRecurId = toOriginTime(recurrenceId);
-            sqlite3_bind_int64(stmt1, index, secsRecurId);
+            SL3_bind_int64(stmt1, index, secsRecurId);
         } else {
             // no recurrenceId, bind NULL
             // note that sqlite3_bind_null doesn't seem to work here
             // also note that sqlite should bind NULL automatically if nothing
             // is bound, but that doesn't work either
-            sqlite3_bind_int64(stmt1, index, 0);
+            SL3_bind_int64(stmt1, index, 0);
         }
 
         count = d->loadIncidences(stmt1);
@@ -400,9 +400,9 @@ bool SqliteStorage::loadSeries(const QString &uid)
         query1 = SELECT_COMPONENTS_BY_UID;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_UID);
 
-        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+        SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
         u = uid.toUtf8();
-        sqlite3_bind_text(stmt1, index, u.constData(), u.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, u.constData(), u.length(), SQLITE_STATIC);
 
         count = d->loadIncidences(stmt1);
     }
@@ -451,27 +451,27 @@ bool SqliteStorage::load(const QDate &start, const QDate &end)
         if (loadStart.isValid() && loadEnd.isValid()) {
             query1 = SELECT_COMPONENTS_BY_DATE_BOTH;
             qsize1 = sizeof(SELECT_COMPONENTS_BY_DATE_BOTH);
-            sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+            SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
             secsStart = toOriginTime(loadStart);
             secsEnd = toOriginTime(loadEnd);
-            sqlite3_bind_int64(stmt1, index, secsEnd);
-            sqlite3_bind_int64(stmt1, index, secsStart);
+            SL3_bind_int64(stmt1, index, secsEnd);
+            SL3_bind_int64(stmt1, index, secsStart);
         } else if (loadStart.isValid()) {
             query1 = SELECT_COMPONENTS_BY_DATE_START;
             qsize1 = sizeof(SELECT_COMPONENTS_BY_DATE_START);
-            sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+            SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
             secsStart = toOriginTime(loadStart);
-            sqlite3_bind_int64(stmt1, index, secsStart);
+            SL3_bind_int64(stmt1, index, secsStart);
         } else if (loadEnd.isValid()) {
             query1 = SELECT_COMPONENTS_BY_DATE_END;
             qsize1 = sizeof(SELECT_COMPONENTS_BY_DATE_END);
-            sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+            SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
             secsEnd = toOriginTime(loadEnd);
-            sqlite3_bind_int64(stmt1, index, secsEnd);
+            SL3_bind_int64(stmt1, index, secsEnd);
         } else {
             query1 = SELECT_COMPONENTS_ALL;
             qsize1 = sizeof(SELECT_COMPONENTS_ALL);
-            sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+            SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
         }
         count = d->loadIncidences(stmt1);
 
@@ -512,9 +512,9 @@ bool SqliteStorage::loadNotebookIncidences(const QString &notebookUid)
         query1 = SELECT_COMPONENTS_BY_NOTEBOOKUID;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_NOTEBOOKUID);
 
-        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+        SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
         u = notebookUid.toUtf8();
-        sqlite3_bind_text(stmt1, index, u.constData(), u.length(), SQLITE_STATIC);
+        SL3_bind_text(stmt1, index, u.constData(), u.length(), SQLITE_STATIC);
 
         count = d->loadIncidences(stmt1);
     }
@@ -570,7 +570,7 @@ bool SqliteStorage::loadJournals()
     query1 = SELECT_COMPONENTS_BY_JOURNAL;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_JOURNAL);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -598,7 +598,7 @@ bool SqliteStorage::loadPlainIncidences()
     query1 = SELECT_COMPONENTS_BY_PLAIN;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_PLAIN);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -626,7 +626,7 @@ bool SqliteStorage::loadRecurringIncidences()
     query1 = SELECT_COMPONENTS_BY_RECURSIVE;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_RECURSIVE);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -654,7 +654,7 @@ bool SqliteStorage::loadGeoIncidences()
     query1 = SELECT_COMPONENTS_BY_GEO;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_GEO);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -684,11 +684,11 @@ bool SqliteStorage::loadGeoIncidences(float geoLatitude, float geoLongitude,
     query1 = SELECT_COMPONENTS_BY_GEO_AREA;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_GEO_AREA);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
-    sqlite3_bind_int64(stmt1, index, geoLatitude - diffLatitude);
-    sqlite3_bind_int64(stmt1, index, geoLongitude - diffLongitude);
-    sqlite3_bind_int64(stmt1, index, geoLatitude + diffLatitude);
-    sqlite3_bind_int64(stmt1, index, geoLongitude + diffLongitude);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_bind_int64(stmt1, index, geoLatitude - diffLatitude);
+    SL3_bind_int64(stmt1, index, geoLongitude - diffLongitude);
+    SL3_bind_int64(stmt1, index, geoLatitude + diffLatitude);
+    SL3_bind_int64(stmt1, index, geoLongitude + diffLongitude);
 
     count = d->loadIncidences(stmt1);
 
@@ -716,7 +716,7 @@ bool SqliteStorage::loadAttendeeIncidences()
     query1 = SELECT_COMPONENTS_BY_ATTENDEE;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_ATTENDEE);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -748,7 +748,7 @@ int SqliteStorage::loadUncompletedTodos()
     query1 = SELECT_COMPONENTS_BY_UNCOMPLETED_TODOS;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_UNCOMPLETED_TODOS);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -799,8 +799,8 @@ int SqliteStorage::loadCompletedTodos(bool hasDate, int limit, QDateTime *last)
         query1 = SELECT_COMPONENTS_BY_COMPLETED_TODOS_AND_CREATED;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_COMPLETED_TODOS_AND_CREATED);
     }
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
-    sqlite3_bind_int64(stmt1, index, secsStart);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_bind_int64(stmt1, index, secsStart);
 
     count = d->loadIncidences(stmt1, limit, last, hasDate);
 
@@ -844,8 +844,8 @@ int SqliteStorage::loadJournals(int limit, QDateTime *last)
     query1 = SELECT_COMPONENTS_BY_JOURNAL_DATE;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_JOURNAL_DATE);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
-    sqlite3_bind_int64(stmt1, index, secsStart);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_bind_int64(stmt1, index, secsStart);
 
     count = d->loadIncidences(stmt1, limit, last, true);
 
@@ -896,8 +896,8 @@ int SqliteStorage::loadIncidences(bool hasDate, int limit, QDateTime *last)
         query1 = SELECT_COMPONENTS_BY_CREATED_SMART;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_CREATED_SMART);
     }
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
-    sqlite3_bind_int64(stmt1, index, secsStart);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_bind_int64(stmt1, index, secsStart);
 
     count = d->loadIncidences(stmt1, limit, last, hasDate);
 
@@ -944,8 +944,8 @@ int SqliteStorage::loadFutureIncidences(int limit, QDateTime *last)
     query1 = SELECT_COMPONENTS_BY_FUTURE_DATE_SMART;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_FUTURE_DATE_SMART);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
-    sqlite3_bind_int64(stmt1, index, secsStart);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_bind_int64(stmt1, index, secsStart);
 
     count = d->loadIncidences(stmt1, limit, last, true, true);
 
@@ -997,8 +997,8 @@ int SqliteStorage::loadGeoIncidences(bool hasDate, int limit, QDateTime *last)
         query1 = SELECT_COMPONENTS_BY_GEO_AND_CREATED;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_GEO_AND_CREATED);
     }
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
-    sqlite3_bind_int64(stmt1, index, secsStart);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_bind_int64(stmt1, index, secsStart);
 
     count = d->loadIncidences(stmt1, limit, last, hasDate);
 
@@ -1038,7 +1038,7 @@ int SqliteStorage::loadUnreadInvitationIncidences()
     query1 = SELECT_COMPONENTS_BY_INVITATION_UNREAD;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_INVITATION_UNREAD);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -1078,8 +1078,8 @@ int SqliteStorage::loadOldInvitationIncidences(int limit, QDateTime *last)
     } else {
         secsStart = LLONG_MAX; // largest time
     }
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
-    sqlite3_bind_int64(stmt1, index, secsStart);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_bind_int64(stmt1, index, secsStart);
 
     count = d->loadIncidences(stmt1, limit, last, false);
 
@@ -1112,7 +1112,7 @@ Person::List SqliteStorage::loadContacts()
     query1 = SELECT_ATTENDEE_AND_COUNT;
     qsize1 = sizeof(SELECT_ATTENDEE_AND_COUNT);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     list = d->mFormat->selectContacts(stmt1);
 
@@ -1144,19 +1144,19 @@ int SqliteStorage::loadContactIncidences(const Person &person, int limit, QDateT
         email = person.email().toUtf8();
         query1 = SELECT_COMPONENTS_BY_ATTENDEE_EMAIL_AND_CREATED;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_ATTENDEE_EMAIL_AND_CREATED);
-        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
-        sqlite3_bind_text(stmt1, index, email, email.length(), SQLITE_STATIC);
+        SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+        SL3_bind_text(stmt1, index, email, email.length(), SQLITE_STATIC);
     } else {
         query1 = SELECT_COMPONENTS_BY_ATTENDEE_AND_CREATED;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_ATTENDEE_AND_CREATED);
-        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
+        SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     }
     if (last->isValid()) {
         secsStart = toOriginTime(*last);
     } else {
         secsStart = LLONG_MAX; // largest time
     }
-    sqlite3_bind_int64(stmt1, index, secsStart);
+    SL3_bind_int64(stmt1, index, secsStart);
 
     count = d->loadIncidences(stmt1, limit, last, false);
 
@@ -1257,12 +1257,12 @@ int SqliteStorage::Private::loadIncidences(sqlite3_stmt *stmt1,
         return false;
     }
 
-    sqlite3_prepare_v2(mDatabase, query2, qsize2, &stmt2, nullptr);
-    sqlite3_prepare_v2(mDatabase, query3, qsize3, &stmt3, nullptr);
-    sqlite3_prepare_v2(mDatabase, query4, qsize4, &stmt4, nullptr);
-    sqlite3_prepare_v2(mDatabase, query5, qsize5, &stmt5, nullptr);
-    sqlite3_prepare_v2(mDatabase, query6, qsize6, &stmt6, nullptr);
-    sqlite3_prepare_v2(mDatabase, query7, qsize7, &stmt7, nullptr);
+    SL3_prepare_v2(mDatabase, query2, qsize2, &stmt2, nullptr);
+    SL3_prepare_v2(mDatabase, query3, qsize3, &stmt3, nullptr);
+    SL3_prepare_v2(mDatabase, query4, qsize4, &stmt4, nullptr);
+    SL3_prepare_v2(mDatabase, query5, qsize5, &stmt5, nullptr);
+    SL3_prepare_v2(mDatabase, query6, qsize6, &stmt6, nullptr);
+    SL3_prepare_v2(mDatabase, query7, qsize7, &stmt7, nullptr);
 
     while ((incidence =
                 mFormat->selectComponents(stmt1, stmt2, stmt3, stmt4, stmt5, stmt6, stmt7, notebookUid))) {
@@ -1373,16 +1373,16 @@ bool SqliteStorage::purgeDeletedIncidences(const KCalendarCore::Incidence::List 
     const char *query = NULL;
 
     query = BEGIN_TRANSACTION;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, size1, &stmt1, NULL);
-    sqlite3_prepare_v2(d->mDatabase, query2, size2, &stmt2, NULL);
-    sqlite3_prepare_v2(d->mDatabase, query3, size3, &stmt3, NULL);
-    sqlite3_prepare_v2(d->mDatabase, query4, size4, &stmt4, NULL);
-    sqlite3_prepare_v2(d->mDatabase, query5, size5, &stmt5, NULL);
-    sqlite3_prepare_v2(d->mDatabase, query6, size6, &stmt6, NULL);
-    sqlite3_prepare_v2(d->mDatabase, query7, size7, &stmt7, NULL);
-    sqlite3_prepare_v2(d->mDatabase, query8, size8, &stmt8, NULL);
+    SL3_prepare_v2(d->mDatabase, query1, size1, &stmt1, NULL);
+    SL3_prepare_v2(d->mDatabase, query2, size2, &stmt2, NULL);
+    SL3_prepare_v2(d->mDatabase, query3, size3, &stmt3, NULL);
+    SL3_prepare_v2(d->mDatabase, query4, size4, &stmt4, NULL);
+    SL3_prepare_v2(d->mDatabase, query5, size5, &stmt5, NULL);
+    SL3_prepare_v2(d->mDatabase, query6, size6, &stmt6, NULL);
+    SL3_prepare_v2(d->mDatabase, query7, size7, &stmt7, NULL);
+    SL3_prepare_v2(d->mDatabase, query8, size8, &stmt8, NULL);
 
     error = 0;
     for (const KCalendarCore::Incidence::Ptr &incidence: list) {
@@ -1403,7 +1403,7 @@ bool SqliteStorage::purgeDeletedIncidences(const KCalendarCore::Incidence::List 
     sqlite3_finalize(stmt8);
 
     query = COMMIT_TRANSACTION;
-    sqlite3_exec(d->mDatabase);
+    SL3_exec(d->mDatabase);
 
  error:
     if (!d->mSem.release()) {
@@ -1640,44 +1640,44 @@ bool SqliteStorage::Private::saveIncidences(QHash<QString, Incidence::Ptr> &list
     QVector<Incidence::Ptr> validIncidences;
 
     query = BEGIN_TRANSACTION;
-    sqlite3_exec(mDatabase);
+    SL3_exec(mDatabase);
 
-    sqlite3_prepare_v2(mDatabase, query1, qsize1, &stmt1, NULL);
+    SL3_prepare_v2(mDatabase, query1, qsize1, &stmt1, NULL);
     if (query2) {
-        sqlite3_prepare_v2(mDatabase, query2, qsize2, &stmt2, NULL);
+        SL3_prepare_v2(mDatabase, query2, qsize2, &stmt2, NULL);
     }
     if (query3) {
-        sqlite3_prepare_v2(mDatabase, query3, qsize3, &stmt3, NULL);
+        SL3_prepare_v2(mDatabase, query3, qsize3, &stmt3, NULL);
     }
     if (query4) {
-        sqlite3_prepare_v2(mDatabase, query4, qsize4, &stmt4, NULL);
+        SL3_prepare_v2(mDatabase, query4, qsize4, &stmt4, NULL);
     }
     if (query5) {
-        sqlite3_prepare_v2(mDatabase, query5, qsize5, &stmt5, NULL);
+        SL3_prepare_v2(mDatabase, query5, qsize5, &stmt5, NULL);
     }
     if (query6) {
-        sqlite3_prepare_v2(mDatabase, query6, qsize6, &stmt6, NULL);
+        SL3_prepare_v2(mDatabase, query6, qsize6, &stmt6, NULL);
     }
     if (query7) {
-        sqlite3_prepare_v2(mDatabase, query7, qsize7, &stmt7, NULL);
+        SL3_prepare_v2(mDatabase, query7, qsize7, &stmt7, NULL);
     }
     if (query8) {
-        sqlite3_prepare_v2(mDatabase, query8, qsize8, &stmt8, NULL);
+        SL3_prepare_v2(mDatabase, query8, qsize8, &stmt8, NULL);
     }
     if (query9) {
-        sqlite3_prepare_v2(mDatabase, query9, qsize9, &stmt9, NULL);
+        SL3_prepare_v2(mDatabase, query9, qsize9, &stmt9, NULL);
     }
     if (query10) {
-        sqlite3_prepare_v2(mDatabase, query10, qsize10, &stmt10, NULL);
+        SL3_prepare_v2(mDatabase, query10, qsize10, &stmt10, NULL);
     }
     if (query11) {
-        sqlite3_prepare_v2(mDatabase, query11, qsize11, &stmt11, NULL);
+        SL3_prepare_v2(mDatabase, query11, qsize11, &stmt11, NULL);
     }
     if (query12) {
-        sqlite3_prepare_v2(mDatabase, query12, qsize12, &stmt12, nullptr);
+        SL3_prepare_v2(mDatabase, query12, qsize12, &stmt12, nullptr);
     }
     if (query13) {
-        sqlite3_prepare_v2(mDatabase, query13, qsize13, &stmt13, nullptr);
+        SL3_prepare_v2(mDatabase, query13, qsize13, &stmt13, nullptr);
     }
     if (dbop == DBInsert) {
         const char *q1 = SELECT_COMPONENTS_BY_UID_RECID_AND_DELETED;
@@ -1697,14 +1697,14 @@ bool SqliteStorage::Private::saveIncidences(QHash<QString, Incidence::Ptr> &list
         const char *q8 = DELETE_ATTACHMENTS;
         int s8 = sizeof(DELETE_ATTACHMENTS);
 
-        sqlite3_prepare_v2(mDatabase, q1, s1, &stmt21, NULL);
-        sqlite3_prepare_v2(mDatabase, q2, s2, &stmt22, NULL);
-        sqlite3_prepare_v2(mDatabase, q3, s3, &stmt23, NULL);
-        sqlite3_prepare_v2(mDatabase, q4, s4, &stmt24, NULL);
-        sqlite3_prepare_v2(mDatabase, q5, s5, &stmt25, NULL);
-        sqlite3_prepare_v2(mDatabase, q6, s6, &stmt26, NULL);
-        sqlite3_prepare_v2(mDatabase, q7, s7, &stmt27, NULL);
-        sqlite3_prepare_v2(mDatabase, q8, s8, &stmt28, NULL);
+        SL3_prepare_v2(mDatabase, q1, s1, &stmt21, NULL);
+        SL3_prepare_v2(mDatabase, q2, s2, &stmt22, NULL);
+        SL3_prepare_v2(mDatabase, q3, s3, &stmt23, NULL);
+        SL3_prepare_v2(mDatabase, q4, s4, &stmt24, NULL);
+        SL3_prepare_v2(mDatabase, q5, s5, &stmt25, NULL);
+        SL3_prepare_v2(mDatabase, q6, s6, &stmt26, NULL);
+        SL3_prepare_v2(mDatabase, q7, s7, &stmt27, NULL);
+        SL3_prepare_v2(mDatabase, q8, s8, &stmt28, NULL);
     }
 
     for (it = list.constBegin(); it != list.constEnd(); ++it) {
@@ -1804,7 +1804,7 @@ bool SqliteStorage::Private::saveIncidences(QHash<QString, Incidence::Ptr> &list
     }
 
     query = COMMIT_TRANSACTION;
-    sqlite3_exec(mDatabase);
+    SL3_exec(mDatabase);
 
     mIsSaved = true;
 
@@ -1951,7 +1951,7 @@ bool SqliteStorage::Private::selectIncidences(Incidence::List *list,
         return false;
     }
 
-    sqlite3_prepare_v2(mDatabase, query1, qsize1, &stmt1, nullptr);
+    SL3_prepare_v2(mDatabase, query1, qsize1, &stmt1, nullptr);
 
     qCDebug(lcMkcal) << "incidences"
              << (dbop == DBInsert ? "inserted" :
@@ -1964,54 +1964,54 @@ bool SqliteStorage::Private::selectIncidences(Incidence::List *list,
             if (dbop == DBInsert) {
                 index = 1;
                 secs = mStorage->toOriginTime(after);
-                sqlite3_bind_int64(stmt1, index, secs);
+                SL3_bind_int64(stmt1, index, secs);
                 if (!notebookUid.isNull()) {
                     index = 2;
                     n = notebookUid.toUtf8();
-                    sqlite3_bind_text(stmt1, index, n.constData(), n.length(), SQLITE_STATIC);
+                    SL3_bind_text(stmt1, index, n.constData(), n.length(), SQLITE_STATIC);
                 }
             }
             if (dbop == DBUpdate || dbop == DBMarkDeleted) {
                 index = 1;
                 secs = mStorage->toOriginTime(after);
-                sqlite3_bind_int64(stmt1, index, secs);
+                SL3_bind_int64(stmt1, index, secs);
                 index = 2;
-                sqlite3_bind_int64(stmt1, index, secs);
+                SL3_bind_int64(stmt1, index, secs);
                 if (!notebookUid.isNull()) {
                     index = 3;
                     n = notebookUid.toUtf8();
-                    sqlite3_bind_text(stmt1, index, n.constData(), n.length(), SQLITE_STATIC);
+                    SL3_bind_text(stmt1, index, n.constData(), n.length(), SQLITE_STATIC);
                 }
             }
             if (dbop == DBSelect) {
                 index = 1;
                 secs = mStorage->toOriginTime(after);
                 qCDebug(lcMkcal) << "QUERY FROM" << secs;
-                sqlite3_bind_int64(stmt1, index, secs);
+                SL3_bind_int64(stmt1, index, secs);
                 index = 2;
                 s = summary.toUtf8();
-                sqlite3_bind_text(stmt1, index, s.constData(), s.length(), SQLITE_STATIC);
+                SL3_bind_text(stmt1, index, s.constData(), s.length(), SQLITE_STATIC);
                 if (!notebookUid.isNull()) {
                     qCDebug(lcMkcal) << "notebook" << notebookUid.toUtf8().constData();
                     index = 3;
                     n = notebookUid.toUtf8();
-                    sqlite3_bind_text(stmt1, index, n.constData(), n.length(), SQLITE_STATIC);
+                    SL3_bind_text(stmt1, index, n.constData(), n.length(), SQLITE_STATIC);
                 }
             }
         } else {
             if (!notebookUid.isNull()) {
                 index = 1;
                 n = notebookUid.toUtf8();
-                sqlite3_bind_text(stmt1, index, n.constData(), n.length(), SQLITE_STATIC);
+                SL3_bind_text(stmt1, index, n.constData(), n.length(), SQLITE_STATIC);
             }
         }
     }
-    sqlite3_prepare_v2(mDatabase, query2, qsize2, &stmt2, nullptr);
-    sqlite3_prepare_v2(mDatabase, query3, qsize3, &stmt3, nullptr);
-    sqlite3_prepare_v2(mDatabase, query4, qsize4, &stmt4, nullptr);
-    sqlite3_prepare_v2(mDatabase, query5, qsize5, &stmt5, nullptr);
-    sqlite3_prepare_v2(mDatabase, query6, qsize6, &stmt6, nullptr);
-    sqlite3_prepare_v2(mDatabase, query7, qsize7, &stmt7, nullptr);
+    SL3_prepare_v2(mDatabase, query2, qsize2, &stmt2, nullptr);
+    SL3_prepare_v2(mDatabase, query3, qsize3, &stmt3, nullptr);
+    SL3_prepare_v2(mDatabase, query4, qsize4, &stmt4, nullptr);
+    SL3_prepare_v2(mDatabase, query5, qsize5, &stmt5, nullptr);
+    SL3_prepare_v2(mDatabase, query6, qsize6, &stmt6, nullptr);
+    SL3_prepare_v2(mDatabase, query7, qsize7, &stmt7, nullptr);
 
     while ((incidence =
                 mFormat->selectComponents(stmt1, stmt2, stmt3, stmt4, stmt5, stmt6, stmt7, nbook))) {
@@ -2183,15 +2183,15 @@ QDateTime SqliteStorage::incidenceDeletedDate(const Incidence::Ptr &incidence)
     sqlite3_stmt *stmt = NULL;
     const char *tail = NULL;
 
-    sqlite3_prepare_v2(d->mDatabase, query, qsize, &stmt, &tail);
+    SL3_prepare_v2(d->mDatabase, query, qsize, &stmt, &tail);
     index = 1;
     u = incidence->uid().toUtf8();
-    sqlite3_bind_text(stmt, index, u.constData(), u.length(), SQLITE_STATIC);
+    SL3_bind_text(stmt, index, u.constData(), u.length(), SQLITE_STATIC);
     if (incidence->hasRecurrenceId()) {
         qint64 secsRecurId = toOriginTime(incidence->recurrenceId());
-        sqlite3_bind_int64(stmt, index, secsRecurId);
+        SL3_bind_int64(stmt, index, secsRecurId);
     } else {
-        sqlite3_bind_int64(stmt, index, 0);
+        SL3_bind_int64(stmt, index, 0);
     }
 
     if (!d->mSem.acquire()) {
@@ -2199,7 +2199,7 @@ QDateTime SqliteStorage::incidenceDeletedDate(const Incidence::Ptr &incidence)
         return deletionDate;
     }
 
-    sqlite3_step(stmt);
+    SL3_step(stmt);
     if ((rv == SQLITE_ROW) || (rv == SQLITE_OK)) {
         date = sqlite3_column_int64(stmt, 1);
         deletionDate = d->mStorage->fromOriginTime(date);
@@ -2228,8 +2228,8 @@ int SqliteStorage::Private::selectCount(const char *query, int qsize)
         return count;
     }
 
-    sqlite3_prepare_v2(mDatabase, query, qsize, &stmt, &tail);
-    sqlite3_step(stmt);
+    SL3_prepare_v2(mDatabase, query, qsize, &stmt, &tail);
+    SL3_step(stmt);
     if ((rv == SQLITE_ROW) || (rv == SQLITE_OK)) {
         count = sqlite3_column_int(stmt, 0);
     }
@@ -2287,7 +2287,7 @@ bool SqliteStorage::loadNotebooks()
 
     d->mIsLoading = true;
 
-    sqlite3_prepare_v2(d->mDatabase, query, qsize, &stmt, &tail);
+    SL3_prepare_v2(d->mDatabase, query, qsize, &stmt, &tail);
 
     while ((nb = d->mFormat->selectCalendars(stmt))) {
         qCDebug(lcMkcal) << "loaded notebook" << nb->uid() << nb->name() << "from database";
@@ -2364,7 +2364,7 @@ bool SqliteStorage::modifyNotebook(const Notebook::Ptr &nb, DBOperation dbop, bo
             return false;
         }
 
-        sqlite3_prepare_v2(d->mDatabase, query, qsize, &stmt, &tail);
+        SL3_prepare_v2(d->mDatabase, query, qsize, &stmt, &tail);
 
         if ((success = d->mFormat->modifyCalendars(nb, dbop, stmt))) {
             qCDebug(lcMkcal) << operation << "notebook" << nb->uid() << nb->name() << "in database";
@@ -2403,8 +2403,8 @@ bool SqliteStorage::Private::checkVersion()
     int major = 0;
     int minor = 0;
 
-    sqlite3_prepare_v2(mDatabase, query, qsize, &stmt, &tail);
-    sqlite3_step(stmt);
+    SL3_prepare_v2(mDatabase, query, qsize, &stmt, &tail);
+    SL3_step(stmt);
     if (rv == SQLITE_ROW) {
         major = sqlite3_column_int(stmt, 0);
         minor = sqlite3_column_int(stmt, 1);
@@ -2417,10 +2417,10 @@ bool SqliteStorage::Private::checkVersion()
         minor = VersionMinor;
         query = INSERT_VERSION;
         qsize = sizeof(INSERT_VERSION);
-        sqlite3_prepare_v2(mDatabase, query, qsize, &stmt, &tail);
-        sqlite3_bind_int(stmt, index, major);
-        sqlite3_bind_int(stmt, index, minor);
-        sqlite3_step(stmt);
+        SL3_prepare_v2(mDatabase, query, qsize, &stmt, &tail);
+        SL3_bind_int(stmt, index, major);
+        SL3_bind_int(stmt, index, minor);
+        SL3_step(stmt);
         qCDebug(lcMkcal) << "inserting version" << major << "." << minor << "in database";
         sqlite3_reset(stmt);
         sqlite3_finalize(stmt);
@@ -2457,9 +2457,9 @@ bool SqliteStorage::Private::saveTimezones()
         QByteArray data = ical.toString(temp, QString()).toUtf8();
 
         // Semaphore is already locked here.
-        sqlite3_prepare_v2(mDatabase, query1, qsize1, &stmt1, NULL);
-        sqlite3_bind_text(stmt1, index, data, data.length(), SQLITE_STATIC);
-        sqlite3_step(stmt1);
+        SL3_prepare_v2(mDatabase, query1, qsize1, &stmt1, NULL);
+        SL3_bind_text(stmt1, index, data, data.length(), SQLITE_STATIC);
+        SL3_step(stmt1);
         success = true;
         mIsSaved = true;
         qCDebug(lcMkcal) << "updated timezones in database";
@@ -2485,14 +2485,14 @@ bool SqliteStorage::Private::loadTimezones()
     sqlite3_stmt *stmt = NULL;
     const char *tail = NULL;
 
-    sqlite3_prepare_v2(mDatabase, query, qsize, &stmt, &tail);
+    SL3_prepare_v2(mDatabase, query, qsize, &stmt, &tail);
 
     if (!mSem.acquire()) {
         qCWarning(lcMkcal) << "cannot lock" << mDatabaseName << "error" << mSem.errorString();
         return false;
     }
 
-    sqlite3_step(stmt);
+    SL3_step(stmt);
     if (rv == SQLITE_ROW) {
         QString zoneData = QString::fromUtf8((const char *)sqlite3_column_text(stmt, 1));
         if (!zoneData.isEmpty()) {

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -321,12 +321,11 @@ bool SqliteStorage::load()
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
 
     query1 = SELECT_COMPONENTS_ALL;
     qsize1 = sizeof(SELECT_COMPONENTS_ALL);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -350,7 +349,6 @@ bool SqliteStorage::load(const QString &uid, const QDateTime &recurrenceId)
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
     int index = 1;
     QByteArray u;
     qint64 secsRecurId;
@@ -359,7 +357,7 @@ bool SqliteStorage::load(const QString &uid, const QDateTime &recurrenceId)
         query1 = SELECT_COMPONENTS_BY_UID_AND_RECURID;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_UID_AND_RECURID);
 
-        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
         u = uid.toUtf8();
         sqlite3_bind_text(stmt1, index, u.constData(), u.length(), SQLITE_STATIC);
         if (recurrenceId.isValid()) {
@@ -395,7 +393,6 @@ bool SqliteStorage::loadSeries(const QString &uid)
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
     int index = 1;
     QByteArray u;
 
@@ -403,7 +400,7 @@ bool SqliteStorage::loadSeries(const QString &uid)
         query1 = SELECT_COMPONENTS_BY_UID;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_UID);
 
-        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
         u = uid.toUtf8();
         sqlite3_bind_text(stmt1, index, u.constData(), u.length(), SQLITE_STATIC);
 
@@ -446,7 +443,6 @@ bool SqliteStorage::load(const QDate &start, const QDate &end)
         int qsize1 = 0;
 
         sqlite3_stmt *stmt1 = NULL;
-        const char *tail1 = NULL;
         int index = 1;
         qint64 secsStart;
         qint64 secsEnd;
@@ -455,7 +451,7 @@ bool SqliteStorage::load(const QDate &start, const QDate &end)
         if (loadStart.isValid() && loadEnd.isValid()) {
             query1 = SELECT_COMPONENTS_BY_DATE_BOTH;
             qsize1 = sizeof(SELECT_COMPONENTS_BY_DATE_BOTH);
-            sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+            sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
             secsStart = toOriginTime(loadStart);
             secsEnd = toOriginTime(loadEnd);
             sqlite3_bind_int64(stmt1, index, secsEnd);
@@ -463,19 +459,19 @@ bool SqliteStorage::load(const QDate &start, const QDate &end)
         } else if (loadStart.isValid()) {
             query1 = SELECT_COMPONENTS_BY_DATE_START;
             qsize1 = sizeof(SELECT_COMPONENTS_BY_DATE_START);
-            sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+            sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
             secsStart = toOriginTime(loadStart);
             sqlite3_bind_int64(stmt1, index, secsStart);
         } else if (loadEnd.isValid()) {
             query1 = SELECT_COMPONENTS_BY_DATE_END;
             qsize1 = sizeof(SELECT_COMPONENTS_BY_DATE_END);
-            sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+            sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
             secsEnd = toOriginTime(loadEnd);
             sqlite3_bind_int64(stmt1, index, secsEnd);
         } else {
             query1 = SELECT_COMPONENTS_ALL;
             qsize1 = sizeof(SELECT_COMPONENTS_ALL);
-            sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+            sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
         }
         count = d->loadIncidences(stmt1);
 
@@ -509,7 +505,6 @@ bool SqliteStorage::loadNotebookIncidences(const QString &notebookUid)
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
     int index = 1;
     QByteArray u;
 
@@ -517,7 +512,7 @@ bool SqliteStorage::loadNotebookIncidences(const QString &notebookUid)
         query1 = SELECT_COMPONENTS_BY_NOTEBOOKUID;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_NOTEBOOKUID);
 
-        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
         u = notebookUid.toUtf8();
         sqlite3_bind_text(stmt1, index, u.constData(), u.length(), SQLITE_STATIC);
 
@@ -571,12 +566,11 @@ bool SqliteStorage::loadJournals()
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
 
     query1 = SELECT_COMPONENTS_BY_JOURNAL;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_JOURNAL);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -600,12 +594,11 @@ bool SqliteStorage::loadPlainIncidences()
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
 
     query1 = SELECT_COMPONENTS_BY_PLAIN;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_PLAIN);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -629,12 +622,11 @@ bool SqliteStorage::loadRecurringIncidences()
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
 
     query1 = SELECT_COMPONENTS_BY_RECURSIVE;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_RECURSIVE);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -658,12 +650,11 @@ bool SqliteStorage::loadGeoIncidences()
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
 
     query1 = SELECT_COMPONENTS_BY_GEO;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_GEO);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -688,13 +679,12 @@ bool SqliteStorage::loadGeoIncidences(float geoLatitude, float geoLongitude,
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
     int index = 1;
 
     query1 = SELECT_COMPONENTS_BY_GEO_AREA;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_GEO_AREA);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     sqlite3_bind_int64(stmt1, index, geoLatitude - diffLatitude);
     sqlite3_bind_int64(stmt1, index, geoLongitude - diffLongitude);
     sqlite3_bind_int64(stmt1, index, geoLatitude + diffLatitude);
@@ -722,12 +712,11 @@ bool SqliteStorage::loadAttendeeIncidences()
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
 
     query1 = SELECT_COMPONENTS_BY_ATTENDEE;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_ATTENDEE);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -755,12 +744,11 @@ int SqliteStorage::loadUncompletedTodos()
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
 
     query1 = SELECT_COMPONENTS_BY_UNCOMPLETED_TODOS;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_UNCOMPLETED_TODOS);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -795,7 +783,6 @@ int SqliteStorage::loadCompletedTodos(bool hasDate, int limit, QDateTime *last)
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
     int index = 1;
     qint64 secsStart;
 
@@ -812,7 +799,7 @@ int SqliteStorage::loadCompletedTodos(bool hasDate, int limit, QDateTime *last)
         query1 = SELECT_COMPONENTS_BY_COMPLETED_TODOS_AND_CREATED;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_COMPLETED_TODOS_AND_CREATED);
     }
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     sqlite3_bind_int64(stmt1, index, secsStart);
 
     count = d->loadIncidences(stmt1, limit, last, hasDate);
@@ -846,7 +833,6 @@ int SqliteStorage::loadJournals(int limit, QDateTime *last)
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
     int index = 1;
     qint64 secsStart;
 
@@ -858,7 +844,7 @@ int SqliteStorage::loadJournals(int limit, QDateTime *last)
     query1 = SELECT_COMPONENTS_BY_JOURNAL_DATE;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_JOURNAL_DATE);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     sqlite3_bind_int64(stmt1, index, secsStart);
 
     count = d->loadIncidences(stmt1, limit, last, true);
@@ -895,7 +881,6 @@ int SqliteStorage::loadIncidences(bool hasDate, int limit, QDateTime *last)
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
     int index = 1;
     qint64 secsStart;
 
@@ -911,7 +896,7 @@ int SqliteStorage::loadIncidences(bool hasDate, int limit, QDateTime *last)
         query1 = SELECT_COMPONENTS_BY_CREATED_SMART;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_CREATED_SMART);
     }
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     sqlite3_bind_int64(stmt1, index, secsStart);
 
     count = d->loadIncidences(stmt1, limit, last, hasDate);
@@ -948,7 +933,6 @@ int SqliteStorage::loadFutureIncidences(int limit, QDateTime *last)
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
     int index = 1;
     qint64 secsStart;
 
@@ -960,7 +944,7 @@ int SqliteStorage::loadFutureIncidences(int limit, QDateTime *last)
     query1 = SELECT_COMPONENTS_BY_FUTURE_DATE_SMART;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_FUTURE_DATE_SMART);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     sqlite3_bind_int64(stmt1, index, secsStart);
 
     count = d->loadIncidences(stmt1, limit, last, true, true);
@@ -998,7 +982,6 @@ int SqliteStorage::loadGeoIncidences(bool hasDate, int limit, QDateTime *last)
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
     int index = 1;
     qint64 secsStart;
 
@@ -1014,7 +997,7 @@ int SqliteStorage::loadGeoIncidences(bool hasDate, int limit, QDateTime *last)
         query1 = SELECT_COMPONENTS_BY_GEO_AND_CREATED;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_GEO_AND_CREATED);
     }
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     sqlite3_bind_int64(stmt1, index, secsStart);
 
     count = d->loadIncidences(stmt1, limit, last, hasDate);
@@ -1051,12 +1034,11 @@ int SqliteStorage::loadUnreadInvitationIncidences()
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
 
     query1 = SELECT_COMPONENTS_BY_INVITATION_UNREAD;
     qsize1 = sizeof(SELECT_COMPONENTS_BY_INVITATION_UNREAD);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     count = d->loadIncidences(stmt1);
 
@@ -1086,7 +1068,6 @@ int SqliteStorage::loadOldInvitationIncidences(int limit, QDateTime *last)
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
     int index = 1;
     qint64 secsStart;
 
@@ -1097,7 +1078,7 @@ int SqliteStorage::loadOldInvitationIncidences(int limit, QDateTime *last)
     } else {
         secsStart = LLONG_MAX; // largest time
     }
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     sqlite3_bind_int64(stmt1, index, secsStart);
 
     count = d->loadIncidences(stmt1, limit, last, false);
@@ -1127,12 +1108,11 @@ Person::List SqliteStorage::loadContacts()
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
 
     query1 = SELECT_ATTENDEE_AND_COUNT;
     qsize1 = sizeof(SELECT_ATTENDEE_AND_COUNT);
 
-    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
     list = d->mFormat->selectContacts(stmt1);
 
@@ -1156,7 +1136,6 @@ int SqliteStorage::loadContactIncidences(const Person &person, int limit, QDateT
     int qsize1 = 0;
 
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
     int index = 1;
     qint64 secsStart = 0;
     QByteArray email;
@@ -1165,12 +1144,12 @@ int SqliteStorage::loadContactIncidences(const Person &person, int limit, QDateT
         email = person.email().toUtf8();
         query1 = SELECT_COMPONENTS_BY_ATTENDEE_EMAIL_AND_CREATED;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_ATTENDEE_EMAIL_AND_CREATED);
-        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
         sqlite3_bind_text(stmt1, index, email, email.length(), SQLITE_STATIC);
     } else {
         query1 = SELECT_COMPONENTS_BY_ATTENDEE_AND_CREATED;
         qsize1 = sizeof(SELECT_COMPONENTS_BY_ATTENDEE_AND_CREATED);
-        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, &tail1);
+        sqlite3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     }
     if (last->isValid()) {
         secsStart = toOriginTime(*last);
@@ -1653,17 +1632,6 @@ bool SqliteStorage::Private::saveIncidences(QHash<QString, Incidence::Ptr> &list
     sqlite3_stmt *stmt26 = NULL;
     sqlite3_stmt *stmt27 = NULL;
     sqlite3_stmt *stmt28 = NULL;
-    const char *tail1 = NULL;
-    const char *tail2 = NULL;
-    const char *tail3 = NULL;
-    const char *tail4 = NULL;
-    const char *tail5 = NULL;
-    const char *tail6 = NULL;
-    const char *tail7 = NULL;
-    const char *tail8 = NULL;
-    const char *tail9 = NULL;
-    const char *tail10 = NULL;
-    const char *tail11 = NULL;
     const char *operation = (dbop == DBInsert) ? "inserting" :
                             (dbop == DBUpdate) ? "updating" : "deleting";
     QHash<QString, Incidence::Ptr>::const_iterator it;
@@ -1674,36 +1642,36 @@ bool SqliteStorage::Private::saveIncidences(QHash<QString, Incidence::Ptr> &list
     query = BEGIN_TRANSACTION;
     sqlite3_exec(mDatabase);
 
-    sqlite3_prepare_v2(mDatabase, query1, qsize1, &stmt1, &tail1);
+    sqlite3_prepare_v2(mDatabase, query1, qsize1, &stmt1, NULL);
     if (query2) {
-        sqlite3_prepare_v2(mDatabase, query2, qsize2, &stmt2, &tail2);
+        sqlite3_prepare_v2(mDatabase, query2, qsize2, &stmt2, NULL);
     }
     if (query3) {
-        sqlite3_prepare_v2(mDatabase, query3, qsize3, &stmt3, &tail3);
+        sqlite3_prepare_v2(mDatabase, query3, qsize3, &stmt3, NULL);
     }
     if (query4) {
-        sqlite3_prepare_v2(mDatabase, query4, qsize4, &stmt4, &tail4);
+        sqlite3_prepare_v2(mDatabase, query4, qsize4, &stmt4, NULL);
     }
     if (query5) {
-        sqlite3_prepare_v2(mDatabase, query5, qsize5, &stmt5, &tail5);
+        sqlite3_prepare_v2(mDatabase, query5, qsize5, &stmt5, NULL);
     }
     if (query6) {
-        sqlite3_prepare_v2(mDatabase, query6, qsize6, &stmt6, &tail6);
+        sqlite3_prepare_v2(mDatabase, query6, qsize6, &stmt6, NULL);
     }
     if (query7) {
-        sqlite3_prepare_v2(mDatabase, query7, qsize7, &stmt7, &tail7);
+        sqlite3_prepare_v2(mDatabase, query7, qsize7, &stmt7, NULL);
     }
     if (query8) {
-        sqlite3_prepare_v2(mDatabase, query8, qsize8, &stmt8, &tail8);
+        sqlite3_prepare_v2(mDatabase, query8, qsize8, &stmt8, NULL);
     }
     if (query9) {
-        sqlite3_prepare_v2(mDatabase, query9, qsize9, &stmt9, &tail9);
+        sqlite3_prepare_v2(mDatabase, query9, qsize9, &stmt9, NULL);
     }
     if (query10) {
-        sqlite3_prepare_v2(mDatabase, query10, qsize10, &stmt10, &tail10);
+        sqlite3_prepare_v2(mDatabase, query10, qsize10, &stmt10, NULL);
     }
     if (query11) {
-        sqlite3_prepare_v2(mDatabase, query11, qsize11, &stmt11, &tail11);
+        sqlite3_prepare_v2(mDatabase, query11, qsize11, &stmt11, NULL);
     }
     if (query12) {
         sqlite3_prepare_v2(mDatabase, query12, qsize12, &stmt12, nullptr);
@@ -2493,7 +2461,6 @@ bool SqliteStorage::Private::saveTimezones()
     const char *query1 = UPDATE_TIMEZONES;
     int qsize1 = sizeof(UPDATE_TIMEZONES);
     sqlite3_stmt *stmt1 = NULL;
-    const char *tail1 = NULL;
 
     const QTimeZone &zone = mCalendar->timeZone();
     if (zone.isValid()) {
@@ -2502,7 +2469,7 @@ bool SqliteStorage::Private::saveTimezones()
         QByteArray data = ical.toString(temp, QString()).toUtf8();
 
         // Semaphore is already locked here.
-        sqlite3_prepare_v2(mDatabase, query1, qsize1, &stmt1, &tail1);
+        sqlite3_prepare_v2(mDatabase, query1, qsize1, &stmt1, NULL);
         sqlite3_bind_text(stmt1, index, data, data.length(), SQLITE_STATIC);
         sqlite3_step(stmt1);
         success = true;

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -1780,29 +1780,17 @@ bool SqliteStorage::Private::saveIncidences(QHash<QString, Incidence::Ptr> &list
 
     sqlite3_finalize(stmt1);
     sqlite3_finalize(stmt2);
-    if (stmt3) {
-        sqlite3_finalize(stmt3);
-    }
+    sqlite3_finalize(stmt3);
     sqlite3_finalize(stmt4);
-    if (stmt5) {
-        sqlite3_finalize(stmt5);
-    }
+    sqlite3_finalize(stmt5);
     sqlite3_finalize(stmt6);
-    if (stmt7) {
-        sqlite3_finalize(stmt7);
-    }
+    sqlite3_finalize(stmt7);
     sqlite3_finalize(stmt8);
-    if (stmt9) {
-        sqlite3_finalize(stmt9);
-    }
+    sqlite3_finalize(stmt9);
     sqlite3_finalize(stmt10);
-    if (stmt11) {
-        sqlite3_finalize(stmt11);
-    }
+    sqlite3_finalize(stmt11);
     sqlite3_finalize(stmt12);
-    if (stmt13) {
-        sqlite3_finalize(stmt13);
-    }
+    sqlite3_finalize(stmt13);
 
     if (dbop == DBInsert) {
         sqlite3_finalize(stmt21);

--- a/src/sqlitestorage.h
+++ b/src/sqlitestorage.h
@@ -434,7 +434,7 @@ public Q_SLOTS:
     void queryFinished();
 };
 
-#define sqlite3_exec( db )                                    \
+#define SL3_exec( db )                                        \
 {                                                             \
  /* kDebug() << "SQL query:" << query;    */                  \
   rv = sqlite3_exec( (db), query, NULL, 0, &errmsg );         \
@@ -455,7 +455,7 @@ public Q_SLOTS:
   }                                                           \
 }
 
-#define sqlite3_prepare_v2( db, query, qsize, stmt, tail )            \
+#define SL3_prepare_v2( db, query, qsize, stmt, tail )                \
 {                                                                     \
  /* kDebug() << "SQL query:" << query;     */                         \
   rv = sqlite3_prepare_v2( (db), (query), (qsize), (stmt), (tail) );  \
@@ -466,7 +466,7 @@ public Q_SLOTS:
   }                                                                   \
 }
 
-#define sqlite3_bind_text( stmt, index, value, size, desc )           \
+#define SL3_bind_text( stmt, index, value, size, desc )               \
 {                                                                     \
   rv = sqlite3_bind_text( (stmt), (index), (value), (size), (desc) ); \
   if ( rv ) {                                                         \
@@ -476,7 +476,7 @@ public Q_SLOTS:
   index++;                                                            \
 }
 
-#define sqlite3_bind_blob( stmt, index, value, size, desc )           \
+#define SL3_bind_blob( stmt, index, value, size, desc )               \
 {                                                                     \
   rv = sqlite3_bind_blob( (stmt), (index), (value), (size), (desc) ); \
   if ( rv ) {                                                         \
@@ -486,7 +486,7 @@ public Q_SLOTS:
   index++;                                                            \
 }
 
-#define sqlite3_bind_int( stmt, index, value )                        \
+#define SL3_bind_int( stmt, index, value )                            \
 {                                                                     \
   rv = sqlite3_bind_int( (stmt), (index), (value) );                  \
   if ( rv ) {                                                         \
@@ -496,7 +496,7 @@ public Q_SLOTS:
   index++;                                                            \
 }
 
-#define sqlite3_bind_int64( stmt, index, value )                      \
+#define SL3_bind_int64( stmt, index, value )                          \
 {                                                                     \
   rv = sqlite3_bind_int64( (stmt), (index), (value) );                \
   if ( rv ) {                                                         \
@@ -506,7 +506,7 @@ public Q_SLOTS:
   index++;                                                            \
 }
 
-#define sqlite3_bind_double( stmt, index, value )                     \
+#define SL3_bind_double( stmt, index, value )                         \
 {                                                                     \
   rv = sqlite3_bind_double( (stmt), (index), (value) );               \
   if ( rv ) {                                                         \
@@ -516,7 +516,7 @@ public Q_SLOTS:
   index++;                                                            \
 }
 
-#define sqlite3_step( stmt )                            \
+#define SL3_step( stmt )                                \
 {                                                       \
   rv = sqlite3_step( (stmt) );                          \
   if ( rv && rv != SQLITE_DONE && rv != SQLITE_ROW ) {  \

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -1611,14 +1611,11 @@ void tst_storage::tst_calendarProperties()
     const char *query = SELECT_CALENDARPROPERTIES_BY_ID;
     int qsize = sizeof(SELECT_CALENDARPROPERTIES_BY_ID);
     sqlite3_stmt *stmt = NULL;
-#undef sqlite3_prepare_v2
     rv = sqlite3_prepare_v2(database, query, qsize, &stmt, NULL);
     QCOMPARE(rv, 0);
     const QByteArray id(uid.toUtf8());
-#undef sqlite3_bind_text
     rv = sqlite3_bind_text(stmt, 1, id.constData(), id.length(), SQLITE_STATIC);
     QCOMPARE(rv, 0);
-#undef sqlite3_step
     rv = sqlite3_step(stmt);
     QCOMPARE(rv, SQLITE_DONE);
     sqlite3_close(database);


### PR DESCRIPTION
Maybe some quick cleanups before i proceed with the schema update. Removed unnecessary tail parameters, unnecessary null check and renamed the sqlite wrappers so they don't get confused with the real api and allow in the future to use either one based on which makes more sense.  

Small detail: used NULL on tail parameters instead of nullptr like a couple of lines did as that felt more c-style for sqlite api.

@chriadam @dcaliste 