### PR TITLE
Simplify database creation

### DIFF
--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -56,7 +56,37 @@ using namespace std;
 
 using namespace mKCal;
 
-const QString gChanged(QLatin1String(".changed"));
+static const QString gChanged(QLatin1String(".changed"));
+
+static const char *createStatements[] =
+{
+    CREATE_TIMEZONES,
+    // Create a global empty entry.
+    INSERT_TIMEZONES,
+    CREATE_CALENDARS,
+    CREATE_COMPONENTS,
+    CREATE_RDATES,
+    CREATE_CUSTOMPROPERTIES,
+    CREATE_RECURSIVE,
+    CREATE_ALARM,
+    CREATE_ATTENDEE,
+    CREATE_ATTACHMENTS,
+    CREATE_CALENDARPROPERTIES,
+    /* Create index on frequently used columns */
+    INDEX_CALENDAR,
+    INDEX_COMPONENT,
+    INDEX_COMPONENT_UID,
+    INDEX_COMPONENT_NOTEBOOK,
+    INDEX_RDATES,
+    INDEX_CUSTOMPROPERTIES,
+    INDEX_RECURSIVE,
+    INDEX_ALARM,
+    INDEX_ATTENDEE,
+    INDEX_ATTACHMENTS,
+    INDEX_CALENDARPROPERTIES,
+    "PRAGMA foreign_keys = ON"
+};
+
 /**
   Private class that helps to provide binary compatibility between releases.
   @internal
@@ -186,76 +216,10 @@ bool SqliteStorage::open()
     // Set one and half second busy timeout for waiting for internal sqlite locks
     sqlite3_busy_timeout(d->mDatabase, 1500);
 
-    /* Create Calendars, Components, etc. tables */
-    query = CREATE_TIMEZONES;
-    SL3_exec(d->mDatabase);
-    // Create a global empty entry.
-    query = INSERT_TIMEZONES;
-    SL3_exec(d->mDatabase);
-
-    query = CREATE_CALENDARS;
-    SL3_exec(d->mDatabase);
-
-    query = CREATE_COMPONENTS;
-    SL3_exec(d->mDatabase);
-
-    query = CREATE_RDATES;
-    SL3_exec(d->mDatabase);
-
-    query = CREATE_CUSTOMPROPERTIES;
-    SL3_exec(d->mDatabase);
-
-    query = CREATE_RECURSIVE;
-    SL3_exec(d->mDatabase);
-
-    query = CREATE_ALARM;
-    SL3_exec(d->mDatabase);
-
-    query = CREATE_ATTENDEE;
-    SL3_exec(d->mDatabase);
-
-    query = CREATE_ATTACHMENTS;
-    SL3_exec(d->mDatabase);
-
-    query = CREATE_CALENDARPROPERTIES;
-    SL3_exec(d->mDatabase);
-
-    /* Create index on frequently used columns */
-    query = INDEX_CALENDAR;
-    SL3_exec(d->mDatabase);
-
-    query = INDEX_COMPONENT;
-    SL3_exec(d->mDatabase);
-
-    query = INDEX_COMPONENT_UID;
-    SL3_exec(d->mDatabase);
-
-    query = INDEX_COMPONENT_NOTEBOOK;
-    SL3_exec(d->mDatabase);
-
-    query = INDEX_RDATES;
-    SL3_exec(d->mDatabase);
-
-    query = INDEX_CUSTOMPROPERTIES;
-    SL3_exec(d->mDatabase);
-
-    query = INDEX_RECURSIVE;
-    SL3_exec(d->mDatabase);
-
-    query = INDEX_ALARM;
-    SL3_exec(d->mDatabase);
-
-    query = INDEX_ATTENDEE;
-    SL3_exec(d->mDatabase);
-
-    query = INDEX_ATTACHMENTS;
-    SL3_exec(d->mDatabase);
-
-    query = INDEX_CALENDARPROPERTIES;
-    SL3_exec(d->mDatabase);
-
-    query = "PRAGMA foreign_keys = ON";
-    SL3_exec(d->mDatabase);
+    for (unsigned int i = 0; i < (sizeof(createStatements)/sizeof(createStatements[0])); i++) {
+         query = createStatements[i];
+         SL3_exec(d->mDatabase);
+    }
 
     if (!d->mChanged.open(QIODevice::Append)) {
         qCWarning(lcMkcal) << "cannot open changed file for" << d->mDatabaseName;

--- a/src/sqlitestorage.h
+++ b/src/sqlitestorage.h
@@ -556,8 +556,6 @@ public Q_SLOTS:
 
 #define INDEX_CALENDAR \
 "CREATE INDEX IF NOT EXISTS IDX_CALENDAR on Calendars(CalendarId)"
-#define INDEX_INVITATION \
-"CREATE INDEX IF NOT EXISTS IDX_INVITATION on Invitations(InvitationId)"
 #define INDEX_COMPONENT \
 "CREATE INDEX IF NOT EXISTS IDX_COMPONENT on Components(ComponentId, Notebook, DateStart, DateEndDue, DateDeleted)"
 #define INDEX_COMPONENT_UID \
@@ -583,8 +581,6 @@ public Q_SLOTS:
 "insert into Timezones values (1, '')"
 #define INSERT_CALENDARS \
 "insert into Calendars values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', '')"
-#define INSERT_INVITATIONS \
-"insert into Invitations values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 #define INSERT_COMPONENTS \
 "insert into Components values (NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, '', 0)"
 #define INSERT_CUSTOMPROPERTIES \
@@ -612,12 +608,8 @@ public Q_SLOTS:
 "update Components set DateDeleted=? where ComponentId=?"
 //"update Components set DateDeleted=strftime('%s','now') where ComponentId=?"
 
-#define DELETE_TIMEZONES \
-"delete from Timezones where TzId=1"
 #define DELETE_CALENDARS \
 "delete from Calendars where CalendarId=?"
-#define DELETE_INVITATIONS \
-"delete from Invitations where InvitationId=?"
 #define DELETE_COMPONENTS \
 "delete from Components where ComponentId=?"
 #define DELETE_RDATES \
@@ -639,8 +631,6 @@ public Q_SLOTS:
 "select * from Timezones where TzId=1"
 #define SELECT_CALENDARS_ALL \
 "select * from Calendars order by Name"
-#define SELECT_INVITATIONS_ALL \
-"select * from Invitations"
 #define SELECT_COMPONENTS_ALL \
 "select * from Components where DateDeleted=0"
 #define SELECT_COMPONENTS_BY_NOTEBOOK \

--- a/src/sqlitestorage.h
+++ b/src/sqlitestorage.h
@@ -41,9 +41,6 @@
 
 namespace mKCal {
 
-const int VersionMajor = 11; // Major version, if different than stored in database, open fails
-const int VersionMinor = 0; // Minor version, if different than stored in database, open warning
-
 /**
   @brief
   This class provides a calendar storage as an sqlite database.
@@ -527,8 +524,6 @@ public Q_SLOTS:
   }                                                     \
 }
 
-#define CREATE_VERSION \
-  "CREATE TABLE IF NOT EXISTS Version(Major INTEGER, Minor INTEGER)"
 #define CREATE_TIMEZONES \
   "CREATE TABLE IF NOT EXISTS Timezones(TzId INTEGER PRIMARY KEY, ICalData TEXT)"
 #define CREATE_CALENDARS \
@@ -584,8 +579,6 @@ public Q_SLOTS:
 #define INDEX_CALENDARPROPERTIES \
 "CREATE INDEX IF NOT EXISTS IDX_CALENDARPROPERTIES on Calendarproperties(CalendarId)"
 
-#define INSERT_VERSION \
-"insert into Version values (?, ?)"
 #define INSERT_TIMEZONES \
 "insert into Timezones values (1, '')"
 #define INSERT_CALENDARS \
@@ -642,8 +635,6 @@ public Q_SLOTS:
 #define DELETE_ATTACHMENTS \
 "delete from Attachments where ComponentId=?"
 
-#define SELECT_VERSION \
-"select * from Version"
 #define SELECT_TIMEZONES \
 "select * from Timezones where TzId=1"
 #define SELECT_CALENDARS_ALL \


### PR DESCRIPTION
Looks like I need to do the schema change work in very small steps to get anything done. Some preparations here out of the way now. Next steps would be actually inserting a user_version and upon opening the db depending on the value and file existence either create the tables or run version migration code.

The old version table and the related code I can already declare useless so just removed that. See individual commits too.

@chriadam @dcaliste 