### PR TITLE
[mkcal] Correct loading of one day incidence.

### DIFF
--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -412,6 +412,7 @@ bool SqliteStorage::load(const QDate &start, const QDate &end)
             secsEnd = toOriginTime(loadEnd);
             SL3_bind_int64(stmt1, index, secsEnd);
             SL3_bind_int64(stmt1, index, secsStart);
+            SL3_bind_int64(stmt1, index, secsStart);
         } else if (loadStart.isValid()) {
             query1 = SELECT_COMPONENTS_BY_DATE_START;
             qsize1 = sizeof(SELECT_COMPONENTS_BY_DATE_START);

--- a/src/sqlitestorage.h
+++ b/src/sqlitestorage.h
@@ -654,7 +654,7 @@ public Q_SLOTS:
 #define SELECT_COMPONENTS_BY_ATTENDEE \
 "select * from components where ComponentId in (select DISTINCT ComponentId from attendee) and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_DATE_BOTH \
-"select * from Components where DateStart<=? and (DateEndDue>=? or DateEndDue=0) and DateDeleted=0"
+"select * from Components where DateStart<=? and (DateEndDue>=? or (DateEndDue=0 and DateStart>=?)) and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_DATE_START \
 "select * from Components where DateEndDue>=? and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_DATE_END \


### PR DESCRIPTION
Previous correction for single day events without
end date set in commit b27fc5637452dd3e44d6b81d9a4860348782a608
created a situation where all single day events
starting before the start date in the loading
range were also included.

@pvuorela , working on timing measurements for loading, I notice that all my birthday events were loaded in a range load for current month. This is erroneous : birthdays should be loaded as recurring events and not in a plain range load (except if the range include the day of birth). After searching a bit, I noticed that single day events (without end date) are wrongly loaded because of the `or DateEndDue = 0` in the SQL query. This case (no end date) should take the start date for the end date constraint. That's what the patch is doing. I've updated the related test accordingly to demonstrate the problem.

Since loading one event takes 6 ms on my device, and I have roughly 50 birthdays saved in my contacts, it's an additional time of 300 ms that is wasted for each range passed to the calendar worker thread. With some tens of events per month, I'm now, with the patch, below 100 ms to load the list of events for one month, which is nice (tm).