### PR TITLE
[mkcal] Add a test measuring saving and loading times.

### DIFF
--- a/rpm/mkcal-qt5.spec
+++ b/rpm/mkcal-qt5.spec
@@ -75,5 +75,6 @@ install -m 644 -p %{SOURCE1} %{buildroot}%{_datadir}/mapplauncherd/privileges.d/
 
 %files tests
 %defattr(-,root,root,-)
+/opt/tests/mkcal/tst_perf
 /opt/tests/mkcal/tst_storage
 /opt/tests/mkcal/tests.xml

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -378,7 +378,8 @@ bool ExtendedStorage::addNotebook(const Notebook::Ptr &nb, bool signal)
         return false;
     }
 
-    if (!calendar()->addNotebook(nb->uid(), nb->isVisible())) {
+    if (!calendar()->hasValidNotebook(nb->uid())
+        && !calendar()->addNotebook(nb->uid(), nb->isVisible())) {
         qCWarning(lcMkcal) << "cannot add notebook" << nb->uid() << "to calendar";
         return false;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,9 @@
-set(SRC
+set(SRC_STORAGE
 	tst_storage.cpp)
-set(HEADERS
+set(HEADERS_STORAGE
 	tst_storage.h)
 
-add_executable(tst_storage ${SRC} ${HEADERS})
+add_executable(tst_storage ${SRC_STORAGE} ${HEADERS_STORAGE})
 
 target_include_directories(tst_storage PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
@@ -18,8 +18,26 @@ target_link_libraries(tst_storage
 add_test(tst_storage tst_storage)
 add_definitions(-DTIMED_SUPPORT)
 
+set(SRC_PERF
+	tst_perf.cpp)
+set(HEADERS_PERF
+	tst_perf.h)
+
+add_executable(tst_perf ${SRC_PERF} ${HEADERS_PERF})
+
+target_include_directories(tst_perf PRIVATE ${PROJECT_SOURCE_DIR}/src)
+
+target_link_libraries(tst_perf
+	Qt5::Test
+	KF5::CalendarCore
+	mkcal-qt5)
+
+add_test(tst_perf tst_perf)
+
 if(INSTALL_TESTS)
 	install(TARGETS tst_storage
+		DESTINATION /opt/tests/mkcal)
+	install(TARGETS tst_perf
 		DESTINATION /opt/tests/mkcal)
 	install(FILES tests.xml
 		DESTINATION /opt/tests/mkcal)

--- a/tests/tst_perf.cpp
+++ b/tests/tst_perf.cpp
@@ -1,0 +1,126 @@
+/*
+  Copyright (c) 2022 Damien Caliste <dcaliste@free.fr>.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Library General Public
+  License as published by the Free Software Foundation; either
+  version 2 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Library General Public License for more details.
+
+  You should have received a copy of the GNU Library General Public License
+  along with this library; see the file COPYING.LIB.  If not, write to
+  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+  Boston, MA 02110-1301, USA.
+*/
+
+#include <QTest>
+#include <QDebug>
+#include <QElapsedTimer>
+#include <QTemporaryFile>
+
+#include "tst_perf.h"
+#include "sqlitestorage.h"
+
+tst_perf::tst_perf(QObject *parent)
+    : QObject(parent)
+    , db(nullptr)
+{
+}
+
+static const int N_EVENTS = 200;
+
+void tst_perf::initTestCase()
+{
+    QString dbFile = QString::fromLatin1(qgetenv("SQLITESTORAGEDB"));
+    if (dbFile.isEmpty()) {
+        db = new QTemporaryFile();
+        db->open();
+        dbFile = db->fileName();
+    }
+    ExtendedCalendar::Ptr cal(new ExtendedCalendar(QTimeZone::systemTimeZone()));
+    m_storage = ExtendedStorage::Ptr(new SqliteStorage(cal, dbFile, true));
+}
+
+void tst_perf::cleanupTestCase()
+{
+    m_storage.clear();
+    if (db)
+        QFile::remove(db->fileName() + ".changed");
+    delete db;
+}
+
+void tst_perf::init()
+{
+    QVERIFY(m_storage->calendar()->rawEvents().isEmpty());
+    QVERIFY(m_storage->open());
+}
+
+void tst_perf::cleanup()
+{
+    QVERIFY(m_storage->close());
+    m_storage->calendar()->close();
+    QVERIFY(m_storage->calendar()->rawEvents().isEmpty());
+}
+
+void tst_perf::tst_save()
+{
+    QElapsedTimer clock;
+
+    clock.start();
+    // Create arbitrary incidences in the DB.
+    for (int i = 0; i < N_EVENTS; i++) {
+        const QDateTime cur = QDateTime::currentDateTimeUtc();
+        KCalendarCore::Event::Ptr event(new KCalendarCore::Event);
+        event->setDtStart(cur.addDays(i));
+        event->setDtEnd(event->dtStart().addSecs(60 * (i + 1)));
+        event->setSummary(QString::fromLatin1("summary"));
+        event->setNonKDECustomProperty("X-FOO", QString::fromLatin1("a property value"));
+        event->setCustomProperty("VOLATILE", "BAR", QString::fromLatin1("another property value"));
+        if (i%3 == 0) {
+            KCalendarCore::Alarm::Ptr alarm = event->newAlarm();
+            alarm->setDisplayAlarm(QString::fromLatin1("Driiiiing"));
+        }
+        if (i%5 == 0) {
+            event->recurrence()->setWeekly(1, cur.date().dayOfWeek());
+            event->recurrence()->setEndDateTime(event->dtEnd().addDays((i + 5) * 7));
+            KCalendarCore::Incidence::Ptr exc = m_storage->calendar()->createException(event, cur.addDays(7));
+            QVERIFY(m_storage->calendar()->addIncidence(exc));
+            i += 1;
+        }
+        QVERIFY(m_storage->calendar()->addIncidence(event));
+    }
+    QCOMPARE(m_storage->calendar()->rawEvents().count(), N_EVENTS);
+    QVERIFY(m_storage->save());
+    qDebug() << "SqliteStorage::save() rate " << float(clock.elapsed()) / N_EVENTS << "ms per event";
+}
+
+void tst_perf::tst_load()
+{
+    QElapsedTimer clock;
+
+    clock.start();
+    QVERIFY(m_storage->load());
+    if (db)
+        // Expected not to be N_EVENTS in case of reading from a database with arbitrary content.
+        QCOMPARE(m_storage->calendar()->rawEvents().count(), N_EVENTS);
+    qDebug() << "SqliteStorage::load() rate " << float(clock.elapsed()) / m_storage->calendar()->rawEvents().count() << "ms per event";
+}
+
+void tst_perf::tst_loadRange()
+{
+    QElapsedTimer clock;
+    const QDate cur = QDateTime::currentDateTimeUtc().date();
+
+    clock.start();
+    QVERIFY(m_storage->load(cur.addDays(-2), cur.addDays(N_EVENTS * 2)));
+    if (db)
+        // Expected not to be N_EVENTS in case of reading from a database with arbitrary content.
+        QCOMPARE(m_storage->calendar()->rawEvents().count(), N_EVENTS);
+    qDebug() << "SqliteStorage::load(range) rate " << float(clock.elapsed()) / m_storage->calendar()->rawEvents().count() << "ms per event";
+}
+
+QTEST_GUILESS_MAIN(tst_perf)

--- a/tests/tst_perf.h
+++ b/tests/tst_perf.h
@@ -1,0 +1,52 @@
+/*
+  Copyright (c) 2022 Damien Caliste <dcaliste@free.fr>.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Library General Public
+  License as published by the Free Software Foundation; either
+  version 2 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Library General Public License for more details.
+
+  You should have received a copy of the GNU Library General Public License
+  along with this library; see the file COPYING.LIB.  If not, write to
+  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+  Boston, MA 02110-1301, USA.
+*/
+
+#ifndef TST_PERF_H
+#define TST_PERF_H
+
+#include <QObject>
+
+#include "extendedstorage.h"
+
+using namespace mKCal;
+
+class QTemporaryFile;
+class tst_perf: public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit tst_perf(QObject *parent = 0);
+
+private slots:
+    void initTestCase();
+    void cleanupTestCase();
+    void init();
+    void cleanup();
+
+    void tst_save();
+    void tst_load();
+    void tst_loadRange();
+
+private:
+    ExtendedStorage::Ptr m_storage;
+    QTemporaryFile *db;
+};
+
+#endif


### PR DESCRIPTION
@pvuorela, this is adding a test whose purpose is to display timing for read and write in the database. This would allow to check that we don't create any obvious regression in term of timing when modifying the database code.

When used on #10 for instance, it shows that there is no penalty (or gain) done by moving the statements into the private part of SqliteFormat.

The test is design to work with an ad hoc temporary database, created on the fly with custom properties, recurrences, exceptions and alarms. But in case one want to run it on an existing database, one can use the well-known environment variable `SQLITESTORAGEDB`.

What do you think ?