### PR TITLE
Local time handling

### DIFF
--- a/src/sqliteformat.cpp
+++ b/src/sqliteformat.cpp
@@ -1217,13 +1217,7 @@ static QDateTime getDateTime(SqliteStorage *storage, sqlite3_stmt *stmt, int ind
             dateTime.setTimeSpec(Qt::LocalTime);
         }
         if (isDate) {
-            // This is a workaround, for wrongly stored date
-            // as a date and time and not as a floating date.
-            QTime localTime(dateTime.time());
-            *isDate = dateTime.isValid() &&
-                localTime.hour() == 0 &&
-                localTime.minute() == 0 &&
-                localTime.second() == 0;
+            *isDate = false;
         }
     } else if (timezone == QStringLiteral(FLOATING_DATE)) {
         date = sqlite3_column_int64(stmt, index + 1);

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -317,7 +317,11 @@ bool SqliteStorage::load(const QString &uid, const QDateTime &recurrenceId)
         u = uid.toUtf8();
         SL3_bind_text(stmt1, index, u.constData(), u.length(), SQLITE_STATIC);
         if (recurrenceId.isValid()) {
-            secsRecurId = toOriginTime(recurrenceId);
+            if (recurrenceId.timeSpec() == Qt::LocalTime) {
+                secsRecurId = toLocalOriginTime(recurrenceId);
+            } else {
+                secsRecurId = toOriginTime(recurrenceId);
+            }
             SL3_bind_int64(stmt1, index, secsRecurId);
         } else {
             // no recurrenceId, bind NULL
@@ -2165,7 +2169,12 @@ QDateTime SqliteStorage::incidenceDeletedDate(const Incidence::Ptr &incidence)
     u = incidence->uid().toUtf8();
     SL3_bind_text(stmt, index, u.constData(), u.length(), SQLITE_STATIC);
     if (incidence->hasRecurrenceId()) {
-        qint64 secsRecurId = toOriginTime(incidence->recurrenceId());
+        qint64 secsRecurId;
+        if (incidence->recurrenceId().timeSpec() == Qt::LocalTime) {
+            secsRecurId = toLocalOriginTime(incidence->recurrenceId());
+        } else {
+            secsRecurId = toOriginTime(incidence->recurrenceId());
+        }
         SL3_bind_int64(stmt, index, secsRecurId);
     } else {
         SL3_bind_int64(stmt, index, 0);

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -1472,16 +1472,16 @@ void tst_storage::tst_icalAllDay_data()
         << QStringLiteral("14B902BC-8D24-4A97-8541-63DF7FD41A70")
         << QStringLiteral("BEGIN:VEVENT\n"
                           "DTSTART:20190607T000000\n"
-                          "DTEND:20190607T000000\n"
+                          "DTEND:20190608T000000\n"
                           "UID:14B902BC-8D24-4A97-8541-63DF7FD41A70\n"
                           "SUMMARY:Test03\n"
                           "END:VEVENT")
-        << true;
+        << false;
     QTest::newRow("UTC")
         << QStringLiteral("14B902BC-8D24-4A97-8541-63DF7FD41A71")
         << QStringLiteral("BEGIN:VEVENT\n"
                           "DTSTART:20190607T000000Z\n"
-                          "DTEND:20190607T000000Z\n"
+                          "DTEND:20190608T000000Z\n"
                           "UID:14B902BC-8D24-4A97-8541-63DF7FD41A71\n"
                           "SUMMARY:Test03\n"
                           "END:VEVENT")
@@ -1491,11 +1491,11 @@ void tst_storage::tst_icalAllDay_data()
         << QStringLiteral("14B902BC-8D24-4A97-8541-63DF7FD41A72")
         << QStringLiteral("BEGIN:VEVENT\n"
                           "DTSTART;TZID=%1:20190607T000000\n"
-                          "DTEND;TZID=%1:20190607T000000\n"
+                          "DTEND;TZID=%1:20190608T000000\n"
                           "UID:14B902BC-8D24-4A97-8541-63DF7FD41A72\n"
                           "SUMMARY:Test03\n"
                           "END:VEVENT").arg(zid)
-        << false; // TODO: FIXME: MR#17 addresses this issue.
+        << false;
     QTest::newRow("floating date")
         << QStringLiteral("14B902BC-8D24-4A97-8541-63DF7FD41A73")
         << QStringLiteral("BEGIN:VEVENT\n"
@@ -1521,6 +1521,7 @@ void tst_storage::tst_icalAllDay()
     QVERIFY(format.fromString(m_calendar, icsData));
     KCalendarCore::Event::Ptr event = m_calendar->event(uid);
     QVERIFY(event);
+    QCOMPARE(event->allDay(), allDay);
 
     m_storage->save();
     reloadDb();

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -393,7 +393,10 @@ void tst_storage::tst_recurrenceExpansion()
     QFETCH(QStringList, expectedEvents);
 
     const QByteArray TZenv(qgetenv("TZ"));
-    qputenv("TZ", expansionTimeZone);
+    // Ensure testing of the creation of the event
+    // is done in a timezone different from the event
+    // time zone and from the expansionTimeZone.
+    qputenv("TZ", "UTC");
 
     // Create an event which occurs every weekday of every week,
     // starting from Friday the 8th of November, from 2 am until 3 am.
@@ -443,6 +446,7 @@ void tst_storage::tst_recurrenceExpansion()
 
     m_storage->save();
     const QString uid = event->uid();
+    qputenv("TZ", expansionTimeZone);
     reloadDb();
 
     auto fetchEvent = m_calendar->event(uid);


### PR DESCRIPTION
@pvuorela, trying to fix the broken test (see tst_icalAllDay), I noticed that local time start and stop times were not saved as such, but saved as time zone events within the system time zone.

This is due to the fact that `QDateTime::timeZone()` is returning the system time zone for events with Qt::LocalTime spec. So everything is working as long as one does not change the time zone of the device, where local time events are not floating anymore but pinned to the previous system time zone. The change was easy, not to save the time zone in case of Qt::LocalTime spec. Particularly, this case where the time zone database column is empty was already existing in the reading part, and already properly restoring date time to a local time spec. So far so good.

But doing this created a major issue : recurrenceId may also be given as floating time. Imagine a recurring event defined as floating time every day at noon (lunch time !). You may be interested to create an exception for a particular day, to move the lunch time to 1 pm. In that case the recurrenceId will be `20220130T120000`. Storing it in the database will result in the three fields:
- recurId = 20220130T110000Z (assuming the device is in a +0100 time zone at the moment of saving)
- recurIdLocal = 20220130T120000
- recurIdTimeZone = ""
Then when you look for this exception in the database, there is a SQL equality test that is done on the `recurId` column. So in our case, it is testing if 20220130T110000Z (stored) == 20220130T120000 (incidence->recurrenceId()). And this test is valid only if you are still in a +0100 time zone. If you have changed time zone, the exception cannot be found again…
The solution is to store the recurIdLocal value in the recurId column for Qt::LocalTime spec events. And also (since SQL is storing integers and not dates) to convert the recurrenceId() with the proper `toLocalOriginTime()` function for Qt::LocalTime events. This is the first commit. It's a bit tricky to understand, but I think it's quite safe. Tests are still properly passing (and they detected the recurrenceId issue if not done properly).

Now (once again), it is creating an issue with the LocalTime events starting and stopping at 00:00. Previously, the case of empty time zone column was not hit (except by legacy issues in the database) in `SqliteFormat::getDateTime()`, but now it can be hit. And on read the mentioned workaround returning a isDate = true for local date time at 00:00 is also hit, making the workaround when reading the endTime for events (the one removing one day) works for these cases also. But one day is added only for all day events during write. While KCalendarCore and RFC5545 are not reporting those local time events at 00:00 as full days. So on write the day is not added, but on read it is. This is inconsistent.
- either we work around KCalendarCore and RFC and add a test when writing to make such cases all day (thus one day will be added to the end date time),
- or we remove the workaround on read.

I chose the second part. I'm really afraid this may create (once again full-day) issues for some services that ill-define the full day events, but I prefer to avoid workarounds in mKCal. Logic there is already quite complex not to add divergences with KCalendarCore and RFC.

This is a tricky decision, @pvuorela what do you think ?