### PR TITLE
[mkcal] Make ExtendedStorage clears the notebook references on close.

### DIFF
--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -118,6 +118,16 @@ ExtendedStorage::~ExtendedStorage()
     delete d;
 }
 
+bool ExtendedStorage::close()
+{
+    clearLoaded();
+
+    d->mNotebooks.clear();
+    d->mDefaultNotebook = Notebook::Ptr();
+
+    return true;
+}
+
 void ExtendedStorage::clearLoaded()
 {
     d->mStart = QDate();

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -376,7 +376,7 @@ public:
       @copydoc
       CalStorage::close()
     */
-    virtual bool close() = 0;
+    virtual bool close();
 
     // Internal Calendar Listener Methods //
 

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -2148,7 +2148,11 @@ QDateTime SqliteStorage::incidenceDeletedDate(const Incidence::Ptr &incidence)
     QByteArray u;
     int rv = 0;
     sqlite3_int64 date;
-    QDateTime deletionDate = QDateTime();
+    QDateTime deletionDate;
+
+    if (!d->mIsOpened) {
+        return deletionDate;
+    }
 
     const char *query = SELECT_COMPONENTS_BY_UID_RECID_AND_DELETED;
     int qsize = sizeof(SELECT_COMPONENTS_BY_UID_RECID_AND_DELETED);
@@ -2194,6 +2198,10 @@ int SqliteStorage::Private::selectCount(const char *query, int qsize)
     int count = 0;
     sqlite3_stmt *stmt = NULL;
     const char *tail = NULL;
+
+    if (!mIsOpened) {
+        return count;
+    }
 
     if (!mSem.acquire()) {
         qCWarning(lcMkcal) << "cannot lock" << mDatabaseName << "error" << mSem.errorString();
@@ -2252,6 +2260,10 @@ bool SqliteStorage::loadNotebooks()
 
     Notebook::Ptr nb;
 
+    if (!d->mIsOpened) {
+        return false;
+    }
+
     if (!d->mSem.acquire()) {
         qCWarning(lcMkcal) << "cannot lock" << d->mDatabaseName << "error" << d->mSem.errorString();
         return false;
@@ -2293,6 +2305,10 @@ error:
 
 bool SqliteStorage::reloadNotebooks()
 {
+    if (!d->mIsOpened) {
+        return false;
+    }
+
     Notebook::List list = notebooks();
     Notebook::List::Iterator it = list.begin();
     d->mIsLoading = true;
@@ -2314,6 +2330,10 @@ bool SqliteStorage::modifyNotebook(const Notebook::Ptr &nb, DBOperation dbop, bo
     const char *tail = NULL;
     const char *operation = (dbop == DBInsert) ? "inserting" :
                             (dbop == DBUpdate) ? "updating" : "deleting";
+
+    if (!d->mIsOpened) {
+        return false;
+    }
 
     if (!d->mIsLoading) {
         // Execute database operation.
@@ -2369,6 +2389,10 @@ bool SqliteStorage::Private::saveTimezones()
     int index = 1;
     bool success = false;
 
+    if (!mIsOpened) {
+        return false;
+    }
+
     const char *query1 = UPDATE_TIMEZONES;
     int qsize1 = sizeof(UPDATE_TIMEZONES);
     sqlite3_stmt *stmt1 = NULL;
@@ -2402,6 +2426,10 @@ bool SqliteStorage::Private::loadTimezones()
 {
     int rv = 0;
     bool success = false;
+
+    if (!mIsOpened) {
+        return false;
+    }
 
     const char *query = SELECT_TIMEZONES;
     int qsize = sizeof(SELECT_TIMEZONES);

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -1793,7 +1793,7 @@ bool SqliteStorage::close()
         d->mDatabase = 0;
         d->mIsOpened = false;
     }
-    return true;
+    return ExtendedStorage::close();
 }
 
 void SqliteStorage::calendarModified(bool modified, Calendar *calendar)


### PR DESCRIPTION
This commit allows to re-open() a closed ExtendedStorage
object, without it complaining on notebook addition failures.

@pvuorela, not a big deal (hopefully, never sure with mKCal), but this is to supress the warning message in the new timing test. It's due to the fact that:
- open()
- do something…
- close()
- open() again

is not working. That's because the notebooks are not cleared from memory on close, and on re-open, they are already existing and cannot be added to the ExtendedStorage.