### PR TITLE
Fix an issue with attendee saving and add some more flexibility to service handler

### DIFF
--- a/src/servicehandler.cpp
+++ b/src/servicehandler.cpp
@@ -51,7 +51,10 @@ ServiceHandlerPrivate::ServiceHandlerPrivate() : mLoaded(false), mDownloadId(0),
 
 void ServiceHandlerPrivate::loadPlugins()
 {
-    QDir pluginsDir(QLatin1String(MKCALPLUGINDIR));
+    QString pluginPath = QLatin1String(qgetenv("MKCAL_PLUGIN_DIR"));
+    if (pluginPath.isEmpty())
+        pluginPath = QLatin1String(MKCALPLUGINDIR);
+    QDir pluginsDir(pluginPath);
     qCDebug(lcMkcal) << "LOADING !!!! Plugin directory" << pluginsDir.path();
 
     foreach (const QString &fileName, pluginsDir.entryList(QDir::Files)) {
@@ -393,19 +396,17 @@ QStringList ServiceHandler::availableServices()
 
 QString ServiceHandler::icon(QString serviceId)
 {
-    if (!d->mLoaded)
-        d->loadPlugins();
-
-    QHash<QString, ServiceInterface *>::const_iterator i = d->mServices.find(serviceId);
-
-    if (i != d->mServices.end()) {
-        return i.value()->icon();
-    } else {
-        return QString();
-    }
+    ServiceInterface *plugin = service(serviceId);
+    return plugin ? plugin->icon() : QString();
 }
 
 QString ServiceHandler::uiName(QString serviceId)
+{
+    ServiceInterface *plugin = service(serviceId);
+    return plugin ? plugin->uiName() : QString();
+}
+
+ServiceInterface* ServiceHandler::service(const QString &serviceId)
 {
     if (!d->mLoaded)
         d->loadPlugins();
@@ -413,9 +414,9 @@ QString ServiceHandler::uiName(QString serviceId)
     QHash<QString, ServiceInterface *>::const_iterator i = d->mServices.find(serviceId);
 
     if (i != d->mServices.end()) {
-        return i.value()->uiName();
+        return i.value();
     } else {
-        return QString();
+        return nullptr;
     }
 }
 

--- a/src/servicehandler.h
+++ b/src/servicehandler.h
@@ -224,13 +224,20 @@ public:
       */
     QString icon(QString serviceId);
 
-    /** \brief Get the Name tp be shown on the UI of a service based on the id of the plugin
+    /** \brief Get the Name to be shown on the UI of a service based on the id of the plugin
 
       @return Name of the service
       @see availableMulticalendarServices
 
       */
     QString uiName(QString serviceId);
+
+    /** \brief Get the plugin object providing the service.
+
+      @return the plugin object
+      @see availableMulticalendarServices
+      */
+    ServiceInterface* service(const QString &serviceId);
 
 signals:
     /** Monitors the progress of the download. The id is the return value got when download started */

--- a/src/sqliteformat.cpp
+++ b/src/sqliteformat.cpp
@@ -1021,7 +1021,9 @@ bool SqliteFormat::Private::insertAttendees(Incidence::Ptr incidence, int rowid)
     QString organizerEmail;
     if (!incidence->organizer().isEmpty()) {
         organizerEmail = incidence->organizer().email();
-        const Attendee organizer(incidence->organizer().name(), organizerEmail);
+        Attendee organizer = incidence->attendeeByMail(organizerEmail);
+        if (organizer.isNull())
+            organizer = Attendee(incidence->organizer().name(), organizerEmail);
         if (!insertAttendee(rowid, organizer, true)) {
             qCWarning(lcMkcal) << "failed to modify organizer for incidence" << incidence->uid();
             success = false;

--- a/tests/tst_storage.h
+++ b/tests/tst_storage.h
@@ -78,6 +78,7 @@ private slots:
     void tst_addIncidence();
     void tst_attachments();
     void tst_populateFromIcsData();
+    void tst_attendees();
 
 private:
     void openDb(bool clear = false);


### PR DESCRIPTION
While working on attendee support in nemo-qml-plugin-calendar, I noticed that it's not convenient to default to the invitation plugin in tests. I'm thus adding a commit here so mKCal can look for plugins in a directory that can be given with an environment variable. Then tests can use this variable to load ad hoc plugins from the test directory without poluting the system directories.

I also noticed that saving the organizer as an attendee was not optimal when the organizer is actually in the attendee list, because his role, status and RSVP were resetted to default values. I've added a test demonstrating the problem and I added a fix in the saving code : if the organizer is in the attendee list, use it's attendee definition instead of creating a new one.

@pvuorela , not in a hurry, when you have a moment to give a look. Thank you.