### PR TITLE
[mkcal] Add a new storage observer signal on DB update

### DIFF
--- a/rpm/mkcal-qt5.spec
+++ b/rpm/mkcal-qt5.spec
@@ -1,7 +1,7 @@
 Name:       mkcal-qt5
 
-Summary:    Extended KDE kcal calendar library port for Maemo
-Version:    0.5.45
+Summary:    SQlite storage backend for KCalendarCore
+Version:    0.5.58
 Release:    1
 License:    LGPLv2+
 URL:        https://github.com/sailfishos/mkcal
@@ -20,7 +20,7 @@ BuildRequires:  pkgconfig(timed-qt5) >= 2.88
 BuildRequires:  pkgconfig(QmfClient)
 
 %description
-Extended KDE kcal calendar library port for Maemo
+Extends KDE calendar core library and provides an SQlite backend.
 
 
 %package devel

--- a/src/extendedcalendar.cpp
+++ b/src/extendedcalendar.cpp
@@ -1392,19 +1392,6 @@ void ExtendedCalendar::storageModified(ExtendedStorage *storage, const QString &
     close();
 }
 
-void ExtendedCalendar::storageProgress(ExtendedStorage *storage, const QString &info)
-{
-    Q_UNUSED(storage);
-    Q_UNUSED(info);
-}
-
-void ExtendedCalendar::storageFinished(ExtendedStorage *storage, bool error, const QString &info)
-{
-    Q_UNUSED(storage);
-    Q_UNUSED(error);
-    Q_UNUSED(info);
-}
-
 int ExtendedCalendar::eventCount(const QString &notebookUid)
 {
     Event::List events = rawEvents();

--- a/src/extendedcalendar.h
+++ b/src/extendedcalendar.h
@@ -748,9 +748,6 @@ protected:
        contents on the storage change.
      */
     virtual void storageModified(ExtendedStorage *storage, const QString &info);
-    virtual void storageProgress(ExtendedStorage *storage, const QString &info);
-    virtual void storageFinished(ExtendedStorage *storage, bool error, const QString &info);
-
 
 private:
     //@cond PRIVATE

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -31,6 +31,7 @@
   @author Cornelius Schumacher \<schumacher@kde.org\>
 */
 #include "extendedstorage.h"
+#include "extendedstorageobserver.h"
 #include "logging_p.h"
 
 #include <KCalendarCore/Exceptions>
@@ -294,29 +295,27 @@ void ExtendedStorage::setIsInvitationIncidencesLoaded(bool loaded)
     d->mIsInvitationIncidencesLoaded = loaded;
 }
 
-#if 0
-void ExtendedStorage::ExtendedStorageObserver::storageModified(ExtendedStorage *storage,
-                                                               const QString &info)
+void ExtendedStorageObserver::storageModified(ExtendedStorage *storage,
+                                              const QString &info)
 {
     Q_UNUSED(storage);
     Q_UNUSED(info);
 }
 
-void ExtendedStorage::ExtendedStorageObserver::storageProgress(ExtendedStorage *storage,
-                                                               const QString &info)
+void ExtendedStorageObserver::storageProgress(ExtendedStorage *storage,
+                                              const QString &info)
 {
     Q_UNUSED(storage);
     Q_UNUSED(info);
 }
 
-void ExtendedStorage::ExtendedStorageObserver::storageFinished(ExtendedStorage *storage,
-                                                               bool error, const QString &info)
+void ExtendedStorageObserver::storageFinished(ExtendedStorage *storage,
+                                              bool error, const QString &info)
 {
     Q_UNUSED(storage);
     Q_UNUSED(error);
     Q_UNUSED(info);
 }
-#endif
 
 void ExtendedStorage::registerObserver(ExtendedStorageObserver *observer)
 {

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -317,6 +317,17 @@ void ExtendedStorageObserver::storageFinished(ExtendedStorage *storage,
     Q_UNUSED(info);
 }
 
+void ExtendedStorageObserver::storageUpdated(ExtendedStorage *storage,
+                                             const KCalendarCore::Incidence::List &added,
+                                             const KCalendarCore::Incidence::List &modified,
+                                             const KCalendarCore::Incidence::List &deleted)
+{
+    Q_UNUSED(storage);
+    Q_UNUSED(added);
+    Q_UNUSED(modified);
+    Q_UNUSED(deleted);
+}
+
 void ExtendedStorage::registerObserver(ExtendedStorageObserver *observer)
 {
     if (!d->mObservers.contains(observer)) {
@@ -360,6 +371,15 @@ void ExtendedStorage::setFinished(bool error, const QString &info)
 {
     foreach (ExtendedStorageObserver *observer, d->mObservers) {
         observer->storageFinished(this, error, info);
+    }
+}
+
+void ExtendedStorage::setUpdated(const KCalendarCore::Incidence::List &added,
+                                 const KCalendarCore::Incidence::List &modified,
+                                 const KCalendarCore::Incidence::List &deleted)
+{
+    foreach (ExtendedStorageObserver *observer, d->mObservers) {
+        observer->storageUpdated(this, added, modified, deleted);
     }
 }
 

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -310,13 +310,6 @@ void ExtendedStorageObserver::storageModified(ExtendedStorage *storage,
     Q_UNUSED(info);
 }
 
-void ExtendedStorageObserver::storageProgress(ExtendedStorage *storage,
-                                              const QString &info)
-{
-    Q_UNUSED(storage);
-    Q_UNUSED(info);
-}
-
 void ExtendedStorageObserver::storageFinished(ExtendedStorage *storage,
                                               bool error, const QString &info)
 {
@@ -365,13 +358,6 @@ void ExtendedStorage::setModified(const QString &info)
 
     foreach (ExtendedStorageObserver *observer, d->mObservers) {
         observer->storageModified(this, info);
-    }
-}
-
-void ExtendedStorage::setProgress(const QString &info)
-{
-    foreach (ExtendedStorageObserver *observer, d->mObservers) {
-        observer->storageProgress(this, info);
     }
 }
 

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -94,8 +94,16 @@ public:
     QHash<QString, Notebook::Ptr> mNotebooks; // uid to notebook
     Notebook::Ptr mDefaultNotebook;
 
-    void setAlarmsForNotebook(const KCalendarCore::Incidence::List &incidences, const QString &nbuid);
 #if defined(TIMED_SUPPORT)
+    // These alarm methods are used to communicate with an external
+    // daemon, like timed, to bind Incidence::Alarm with the system notification.
+    void clearAlarms(const Incidence::Ptr &incidence);
+    void clearAlarms(const Incidence::List &incidences);
+    void clearAlarms(const QString &notebookUid);
+    void setAlarms(const Incidence::List &incidences, const Calendar::Ptr &calendar);
+    void resetAlarms(const Incidence::List &incidences, const Calendar::Ptr &calendar);
+
+    void setAlarmsForNotebook(const Incidence::List &incidences, const QString &notebookUid);
     void setAlarms(const Incidence::Ptr &incidence, const QString &nbuid, Timed::Event::List &events, const QDateTime &now);
     void commitEvents(Timed::Event::List &events);
 #endif
@@ -381,6 +389,14 @@ void ExtendedStorage::setUpdated(const KCalendarCore::Incidence::List &added,
     foreach (ExtendedStorageObserver *observer, d->mObservers) {
         observer->storageUpdated(this, added, modified, deleted);
     }
+#if defined(TIMED_SUPPORT)
+    if (!added.isEmpty())
+        d->setAlarms(added, calendar());
+    if (!modified.isEmpty())
+        d->resetAlarms(modified, calendar());
+    if (!deleted.isEmpty())
+        d->clearAlarms(deleted);
+#endif
 }
 
 bool ExtendedStorage::addNotebook(const Notebook::Ptr &nb)
@@ -423,14 +439,16 @@ bool ExtendedStorage::updateNotebook(const Notebook::Ptr &nb)
     if (!modifyNotebook(nb, DBUpdate)) {
         return false;
     }
+#if defined(TIMED_SUPPORT)
     if (wasVisible && !nb->isVisible()) {
-        clearAlarms(nb->uid());
+        d->clearAlarms(nb->uid());
     } else if (!wasVisible && nb->isVisible()) {
         Incidence::List list;
         if (allIncidences(&list, nb->uid())) {
             d->setAlarmsForNotebook(list, nb->uid());
         }
     }
+#endif
 
     return true;
 }
@@ -544,44 +562,74 @@ bool ExtendedStorage::isValidNotebook(const QString &notebookUid)
     return true;
 }
 
-void ExtendedStorage::resetAlarms(const Incidence::Ptr &incidence)
+Notebook::Ptr ExtendedStorage::createDefaultNotebook(QString name, QString color)
 {
-    resetAlarms(Incidence::List(1, incidence));
+    // Could use QUuid::WithoutBraces when moving to Qt5.11.
+    const QString uid(QUuid::createUuid().toString());
+    if (name.isEmpty())
+        name = "Default";
+    if (color.isEmpty())
+        color = "#0000FF";
+    Notebook::Ptr nbDefault(new Notebook(uid.mid(1, uid.length() - 2), name, QString(), color,
+                                         false, true, false, false, true));
+    if (modifyNotebook(nbDefault, DBInsert, false)) {
+        d->mNotebooks.insert(nbDefault->uid(), nbDefault);
+        if (!calendar()->addNotebook(nbDefault->uid(), nbDefault->isVisible())
+            && !calendar()->updateNotebook(nbDefault->uid(), nbDefault->isVisible())) {
+            qCWarning(lcMkcal) << "notebook" << nbDefault->uid() << "already in calendar";
+        }
+    }
+    setDefaultNotebook(nbDefault);
+    return nbDefault;
 }
 
-void ExtendedStorage::resetAlarms(const Incidence::List &incidences)
+Incidence::Ptr ExtendedStorage::checkAlarm(const QString &uid, const QString &recurrenceId,
+                                           bool loadAlways)
+{
+    QDateTime rid;
+
+    if (!recurrenceId.isEmpty()) {
+        rid = QDateTime::fromString(recurrenceId, Qt::ISODate);
+    }
+    Incidence::Ptr incidence = calendar()->incidence(uid, rid);
+    if (!incidence || loadAlways) {
+        load(uid, rid);
+        incidence = calendar()->incidence(uid, rid);
+    }
+    if (incidence && incidence->hasEnabledAlarms()) {
+        // Return incidence if it exists and has active alarms.
+        return incidence;
+    }
+    return Incidence::Ptr();
+}
+
+#if defined(TIMED_SUPPORT)
+// Todo: move this into a service plugin that is a ExtendedStorageObserver.
+void ExtendedStorage::Private::resetAlarms(const Incidence::List &incidences,
+                                           const Calendar::Ptr &calendar)
 {
     clearAlarms(incidences);
-    setAlarms(incidences);
+    setAlarms(incidences, calendar);
 }
 
-void ExtendedStorage::setAlarms(const Incidence::Ptr &incidence)
+void ExtendedStorage::Private::setAlarms(const Incidence::List &incidences,
+                                         const Calendar::Ptr &calendar)
 {
-    setAlarms(Incidence::List(1, incidence));
-}
-
-void ExtendedStorage::setAlarms(const Incidence::List &incidences)
-{
-#if defined(TIMED_SUPPORT)
     const QDateTime now = QDateTime::currentDateTime();
     Timed::Event::List events;
     foreach (const Incidence::Ptr incidence, incidences) {
         // The incidence from the list must be in the calendar and in a notebook.
-        const QString &nbuid = calendar()->notebook(incidence->uid());
-        if (!calendar()->isVisible(incidence) || nbuid.isEmpty()) {
+        const QString &nbuid = calendar->notebook(incidence->uid());
+        if (!calendar->isVisible(incidence) || nbuid.isEmpty()) {
             continue;
         }
-        d->setAlarms(incidence, nbuid, events, now);
+        setAlarms(incidence, nbuid, events, now);
     }
-    d->commitEvents(events);
-#else
-    Q_UNUSED(incidences);
-#endif
+    commitEvents(events);
 }
 
-void ExtendedStorage::clearAlarms(const Incidence::Ptr &incidence)
+void ExtendedStorage::Private::clearAlarms(const Incidence::Ptr &incidence)
 {
-#if defined(TIMED_SUPPORT)
     QMap<QString, QVariant> map;
     map["APPLICATION"] = "libextendedkcal";
     map["uid"] = incidence->uid();
@@ -628,109 +676,54 @@ void ExtendedStorage::clearAlarms(const Incidence::Ptr &incidence)
                                << reply.value() << timed.lastError();
         }
     }
-#else
-    Q_UNUSED(incidence);
-#endif
 }
 
-void ExtendedStorage::clearAlarms(const KCalendarCore::Incidence::List &incidences)
+void ExtendedStorage::Private::clearAlarms(const KCalendarCore::Incidence::List &incidences)
 {
     foreach (const Incidence::Ptr incidence, incidences) {
         clearAlarms(incidence);
     }
 }
 
-void ExtendedStorage::clearAlarms(const QString &nb)
+void ExtendedStorage::Private::clearAlarms(const QString &notebookUid)
 {
-#if defined(TIMED_SUPPORT)
     QMap<QString, QVariant> map;
     map["APPLICATION"] = "libextendedkcal";
-    map["notebook"] = nb;
+    map["notebook"] = notebookUid;
 
     Timed::Interface timed;
     if (!timed.isValid()) {
-        qCWarning(lcMkcal) << "cannot clear alarms for" << nb
+        qCWarning(lcMkcal) << "cannot clear alarms for" << notebookUid
                  << "alarm interface is not valid" << timed.lastError();
         return;
     }
     QDBusReply<QList<QVariant> > reply = timed.query_sync(map);
     if (!reply.isValid()) {
-        qCWarning(lcMkcal) << "cannot clear alarms for" << nb << timed.lastError();
+        qCWarning(lcMkcal) << "cannot clear alarms for" << notebookUid << timed.lastError();
         return;
     }
     const QList<QVariant> &result = reply.value();
     for (int i = 0; i < result.size(); i++) {
         uint32_t cookie = result[i].toUInt();
-        qCDebug(lcMkcal) << "removing alarm" << cookie << nb;
+        qCDebug(lcMkcal) << "removing alarm" << cookie << notebookUid;
         QDBusReply<bool> reply = timed.cancel_sync(cookie);
         if (!reply.isValid() || !reply.value()) {
-            qCWarning(lcMkcal) << "cannot remove alarm" << cookie << nb;
+            qCWarning(lcMkcal) << "cannot remove alarm" << cookie << notebookUid;
         }
     }
-#else
-    Q_UNUSED(nb);
-#endif
 }
 
-Incidence::Ptr ExtendedStorage::checkAlarm(const QString &uid, const QString &recurrenceId,
-                                           bool loadAlways)
+void ExtendedStorage::Private::setAlarmsForNotebook(const Incidence::List &incidences, const QString &notebookUid)
 {
-    QDateTime rid;
-
-    if (!recurrenceId.isEmpty()) {
-        rid = QDateTime::fromString(recurrenceId, Qt::ISODate);
-    }
-    Incidence::Ptr incidence = calendar()->incidence(uid, rid);
-    if (!incidence || loadAlways) {
-        load(uid, rid);
-        incidence = calendar()->incidence(uid, rid);
-    }
-    if (incidence && incidence->hasEnabledAlarms()) {
-        // Return incidence if it exists and has active alarms.
-        return incidence;
-    }
-    return Incidence::Ptr();
-}
-
-
-Notebook::Ptr ExtendedStorage::createDefaultNotebook(QString name, QString color)
-{
-    // Could use QUuid::WithoutBraces when moving to Qt5.11.
-    const QString uid(QUuid::createUuid().toString());
-    if (name.isEmpty())
-        name = "Default";
-    if (color.isEmpty())
-        color = "#0000FF";
-    Notebook::Ptr nbDefault(new Notebook(uid.mid(1, uid.length() - 2), name, QString(), color,
-                                         false, true, false, false, true));
-    if (modifyNotebook(nbDefault, DBInsert, false)) {
-        d->mNotebooks.insert(nbDefault->uid(), nbDefault);
-        if (!calendar()->addNotebook(nbDefault->uid(), nbDefault->isVisible())
-            && !calendar()->updateNotebook(nbDefault->uid(), nbDefault->isVisible())) {
-            qCWarning(lcMkcal) << "notebook" << nbDefault->uid() << "already in calendar";
-        }
-    }
-    setDefaultNotebook(nbDefault);
-    return nbDefault;
-}
-
-void ExtendedStorage::Private::setAlarmsForNotebook(const KCalendarCore::Incidence::List &incidences, const QString &nbuid)
-{
-#if defined(TIMED_SUPPORT)
     const QDateTime now = QDateTime::currentDateTime();
     // list of all timed events
     Timed::Event::List events;
     foreach (const Incidence::Ptr incidence, incidences) {
-        setAlarms(incidence, nbuid, events, now);
+        setAlarms(incidence, notebookUid, events, now);
     }
     commitEvents(events);
-#else
-    Q_UNUSED(incidences);
-    Q_UNUSED(nbuid);
-#endif
 }
 
-#if defined(TIMED_SUPPORT)
 void ExtendedStorage::Private::setAlarms(const Incidence::Ptr &incidence,
                                          const QString &nbuid,
                                          Timed::Event::List &events,

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -674,6 +674,9 @@ protected:
     void setModified(const QString &info);
     void setProgress(const QString &info);
     void setFinished(bool error, const QString &info);
+    void setUpdated(const KCalendarCore::Incidence::List &added,
+                    const KCalendarCore::Incidence::List &modified,
+                    const KCalendarCore::Incidence::List &deleted);
 
     // These alarm methods are used to communicate with an external
     // daemon, like timed, to bind Incidence::Alarm with the system notification.

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -666,7 +666,6 @@ protected:
     void setLoadDates(const QDate &start, const QDate &end);
 
     void setModified(const QString &info);
-    void setProgress(const QString &info);
     void setFinished(bool error, const QString &info);
     void setUpdated(const KCalendarCore::Incidence::List &added,
                     const KCalendarCore::Incidence::List &modified,

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -58,12 +58,6 @@ enum DBOperation {
     DBSelect
 };
 
-// Default alarm receiver is the organiser application.
-const char *const DBusService = "com.nokia.organiser";
-const char *const DBusInterface = "com.nokia.OrganiserAlarmIf";
-const char *const DBusPath = "/";
-const char *const DBusName = "alarm";
-
 /**
   @brief
   This class provides a calendar storage interface.

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -678,16 +678,6 @@ protected:
                     const KCalendarCore::Incidence::List &modified,
                     const KCalendarCore::Incidence::List &deleted);
 
-    // These alarm methods are used to communicate with an external
-    // daemon, like timed, to bind Incidence::Alarm with the system notification.
-    void clearAlarms(const KCalendarCore::Incidence::Ptr &incidence);
-    void clearAlarms(const KCalendarCore::Incidence::List &incidences);
-    void clearAlarms(const QString &nname);
-    void setAlarms(const KCalendarCore::Incidence::Ptr &incidence);
-    void setAlarms(const KCalendarCore::Incidence::List &incidences);
-    void resetAlarms(const KCalendarCore::Incidence::List &incidences);
-    void resetAlarms(const KCalendarCore::Incidence::Ptr &incidence);
-
     bool isUncompletedTodosLoaded();
     void setIsUncompletedTodosLoaded(bool loaded);
 

--- a/src/extendedstorageobserver.h
+++ b/src/extendedstorageobserver.h
@@ -57,7 +57,7 @@ public:
        is being observed.
        @param info uids inserted/updated/deleted, modified file etc.
     */
-    virtual void storageModified(ExtendedStorage *storage, const QString &info) = 0;
+    virtual void storageModified(ExtendedStorage *storage, const QString &info);
 
     /**
        Notify the Observer that a Storage is executing an action.
@@ -68,7 +68,7 @@ public:
        is being observed.
        @param info textual information
     */
-    virtual void storageProgress(ExtendedStorage *storage, const QString &info) = 0;
+    virtual void storageProgress(ExtendedStorage *storage, const QString &info);
 
     /**
        Notify the Observer that a Storage has finished an action.
@@ -78,7 +78,7 @@ public:
        @param error true if action was unsuccessful; false otherwise
        @param info textual information
     */
-    virtual void storageFinished(ExtendedStorage *storage, bool error, const QString &info) = 0;
+    virtual void storageFinished(ExtendedStorage *storage, bool error, const QString &info);
 };
 
 };

--- a/src/extendedstorageobserver.h
+++ b/src/extendedstorageobserver.h
@@ -65,17 +65,6 @@ public:
     virtual void storageModified(ExtendedStorage *storage, const QString &info);
 
     /**
-       Notify the Observer that a Storage is executing an action.
-       This callback is called typically for example every time
-       an incidence has been loaded.
-
-       @param storage is a pointer to the ExtendedStorage object that
-       is being observed.
-       @param info textual information
-    */
-    virtual void storageProgress(ExtendedStorage *storage, const QString &info);
-
-    /**
        Notify the Observer that a Storage has finished an action.
 
        @param storage is a pointer to the ExtendedStorage object that

--- a/src/extendedstorageobserver.h
+++ b/src/extendedstorageobserver.h
@@ -32,6 +32,7 @@
 #define MKCAL_STORAGEOBSERVER_H
 
 #include <QString>
+#include <KCalendarCore/Incidence>
 
 
 namespace mKCal {
@@ -51,7 +52,11 @@ public:
     virtual ~ExtendedStorageObserver() {};
 
     /**
-       Notify the Observer that a Storage has been modified.
+       Notify the Observer that a Storage has been modified by an external
+       process. There is no information about what has been changed.
+
+       See also storageUpdated() for a notification of modifications done
+       in-process.
 
        @param storage is a pointer to the ExtendedStorage object that
        is being observed.
@@ -79,6 +84,26 @@ public:
        @param info textual information
     */
     virtual void storageFinished(ExtendedStorage *storage, bool error, const QString &info);
+
+    /**
+       Notify the Observer that a Storage has been updated to reflect the
+       content of the associated calendar. This notification is delivered
+       because of local changes done in-process by a call to
+       ExtendedStorage::save() for instance.
+
+       See also storageModified() for a notification for modifications
+       done to the database by an external process.
+
+       @param storage is a pointer to the ExtendedStorage object that
+       is being observed.
+       @param added is a list of newly added incidences in the storage
+       @param modified is a list of updated incidences in the storage
+       @param deleted is a list of deleted incidences from the storage
+    */
+    virtual void storageUpdated(ExtendedStorage *storage,
+                                const KCalendarCore::Incidence::List &added,
+                                const KCalendarCore::Incidence::List &modified,
+                                const KCalendarCore::Incidence::List &deleted);
 };
 
 };

--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -121,6 +121,9 @@ public:
     */
     KCalendarCore::Person::List selectContacts();
 
+    bool selectMetadata(int *id);
+    bool incrementTransactionId(int *id);
+
 private:
     //@cond PRIVATE
     Q_DISABLE_COPY(SqliteFormat)

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -140,7 +140,6 @@ public:
     bool mIsOpened;
     bool mIsSaved;
     QDateTime mOriginTime;
-    QString mSparql;
 
     bool addIncidence(const Incidence::Ptr &incidence, const QString &notebookUid);
     int loadIncidences(sqlite3_stmt *stmt1,

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -1376,14 +1376,6 @@ bool SqliteStorage::Private::saveIncidences(QHash<QString, Incidence::Ptr> &list
         }
     }
 
-    if (dbop == DBDelete || dbop == DBMarkDeleted) {
-        // Remove all alarms.
-        mStorage->clearAlarms(validIncidences);
-    } else {
-        // Reset all alarms.
-        mStorage->resetAlarms(validIncidences);
-    }
-
     list.clear();
     // TODO What if there were errors? Options: 1) rollback 2) best effort.
 

--- a/src/sqlitestorage.h
+++ b/src/sqlitestorage.h
@@ -530,6 +530,8 @@ public Q_SLOTS:
   }                                                     \
 }
 
+#define CREATE_METADATA \
+  "CREATE TABLE IF NOT EXISTS Metadata(transactionId INTEGER)"
 #define CREATE_TIMEZONES \
   "CREATE TABLE IF NOT EXISTS Timezones(TzId INTEGER PRIMARY KEY, ICalData TEXT)"
 #define CREATE_CALENDARS \
@@ -604,6 +606,8 @@ public Q_SLOTS:
 #define INSERT_ATTACHMENTS \
 "insert into Attachments values (?, ?, ?, ?, ?, ?, ?)"
 
+#define UPDATE_METADATA \
+"replace into Metadata (rowid, transactionId) values (1, ?)"
 #define UPDATE_TIMEZONES \
 "update Timezones set ICalData=? where TzId=1"
 #define UPDATE_CALENDARS \
@@ -633,6 +637,8 @@ public Q_SLOTS:
 #define DELETE_ATTACHMENTS \
 "delete from Attachments where ComponentId=?"
 
+#define SELECT_METADATA \
+"select * from Metadata where rowid=1"
 #define SELECT_TIMEZONES \
 "select * from Timezones where TzId=1"
 #define SELECT_CALENDARS_ALL \

--- a/tests/tst_storage.h
+++ b/tests/tst_storage.h
@@ -79,6 +79,7 @@ private slots:
     void tst_attachments();
     void tst_populateFromIcsData();
     void tst_attendees();
+    void tst_storageObserver();
 
 private:
     void openDb(bool clear = false);

--- a/tools/mkcaltool/mkcaltool.cpp
+++ b/tools/mkcaltool/mkcaltool.cpp
@@ -47,6 +47,6 @@ int MkcalTool::resetAlarms(const QString &notebookUid, const QString &eventUid)
         return 1;
     }
 
-    storage->resetAlarms(event);
+    storage->setUpdated(KCalendarCore::Incidence::List(), KCalendarCore::Incidence::List() << event, KCalendarCore::Incidence::List());
     return 0;
 }


### PR DESCRIPTION
The existing storageModified() signal is emitted whenever the ".changed" file is touched. Restrict its emission only if some change has been done to the database content from an external process. Currently emit it also if a change is done in process to any notebook.
    
Add a new signal storageUpdated() that is emitted on any modification of the database component parts (addition, modification of deletion) to be in part with the associated mCalendar.

The distinction between the two signals is done internally thanks to a counter saved to the DB in a new Metadata table. On every change this counter is incremented in sync with modifications, saved to DB and stored locally in the SqliteStorage private member. In the `fileChanged` signal handler, this counter is reread from DB. If it doesn't match with the stored value in the private member, the `storageModified` signal is emitted. Otherwise, none (the `storageUpdated` should have been emitted already in that case).

This is a major API break, since the `storageModified` signal is not emitted anymore for in-process modification of the DB. Any client code relying on it must implement an handler for the new `storageUpdated` signal. As far as I know, only sailfishos/nemo-qml-plugin-calendar is using this signal.

I've added a test to check the validity of the new signal.

The other commits are marginal modifications :
- I got bored of re-implementing in observers the methods for signals we are not interested in. And also, adding a new pure virtual method in ExtendedStorageObserver would have broken all existing implementations. So I decided not to make then pure and use a default do-nothing implementation. Anyway, all observer implementers are already linking with mKCal… If this is creating issues I'm not envisioning, don't hesitate to ask me to remove this commit.
- I profited of the new signal to completely move the alarm implementation as a private handler in ExtendedStorage. As I'm mentioning in the code, it could then be implemented as a plugin that implements a storage observer and be completely moved out of ExtendedStorage and friends. A future work maybe if you think it's worth.
- some micro simplification in SqliteStorage where mIsOpened was playing a redundant role with mDatabase being not null.

@pvuorela, this is still under test, but you may begin to give feedback on the design and implementation. I've got a companion PR for QML bindings, making the full `tst_calendarevent` test run on an exiting DB with recurring events and various other events (a copy of my private calendar) decreasing from 2 min. 14 s. to 27 s. \o/