### PR TITLE
[mkcal] Remove optional arguments from addNotebook() and deleteNotebook()

### DIFF
--- a/src/dummystorage.h
+++ b/src/dummystorage.h
@@ -236,10 +236,6 @@ public:
     {
         return true;
     }
-    bool reloadNotebooks()
-    {
-        return true;
-    }
     bool modifyNotebook(const mKCal::Notebook::Ptr &, mKCal::DBOperation, bool)
     {
         return true;

--- a/src/extendedcalendar.cpp
+++ b/src/extendedcalendar.cpp
@@ -1387,8 +1387,6 @@ void ExtendedCalendar::storageModified(ExtendedStorage *storage, const QString &
     Q_UNUSED(storage);
     Q_UNUSED(info);
 
-    clearNotebookAssociations();
-
     // Despite the strange name, close() method does exactly what we
     // want - clears the in-memory contents of the calendar.
     close();

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -336,16 +336,18 @@ void ExtendedStorage::unregisterObserver(ExtendedStorageObserver *observer)
 
 void ExtendedStorage::setModified(const QString &info)
 {
-    // Clear all smart loading variables
-    d->mStart = QDate();
-    d->mEnd = QDate();
-    d->mIsUncompletedTodosLoaded = false;
-    d->mIsCompletedTodosDateLoaded = false;
-    d->mIsCompletedTodosCreatedLoaded = false;
-    d->mIsGeoDateLoaded = false;
-    d->mIsGeoCreatedLoaded = false;
-    d->mIsUnreadIncidencesLoaded = false;
-    d->mIsInvitationIncidencesLoaded = false;
+    clearLoaded();
+    const QStringList list = d->mNotebooks.keys();
+    for (const QString &uid : list) {
+        if (!calendar()->deleteNotebook(uid)) {
+            qCDebug(lcMkcal) << "notebook" << uid << "already removed from calendar";
+        }
+    }
+    d->mNotebooks.clear();
+    d->mDefaultNotebook.clear();
+    if (!loadNotebooks()) {
+        qCWarning(lcMkcal) << "loading notebooks failed";
+    }
 
     foreach (ExtendedStorageObserver *observer, d->mObservers) {
         observer->storageModified(this, info);

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -39,10 +39,6 @@ using namespace KCalendarCore;
 
 #include <QtCore/QUuid>
 
-#if defined(MKCAL_FOR_MEEGO)
-# include <mlocale.h>
-#endif
-
 #ifdef TIMED_SUPPORT
 # include <timed-qt5/interface.h>
 # include <timed-qt5/event-declarations.h>
@@ -368,11 +364,11 @@ void ExtendedStorage::setFinished(bool error, const QString &info)
     }
 }
 
-bool ExtendedStorage::addNotebook(const Notebook::Ptr &nb, bool signal)
+bool ExtendedStorage::addNotebook(const Notebook::Ptr &nb)
 {
     if (nb->uid().length() < 7) {
         // Cannot accept this id, create better one.
-        QByteArray uid(QUuid::createUuid().toByteArray());
+        QString uid(QUuid::createUuid().toString());
         nb->setUid(uid.mid(1, uid.length() - 2));
     }
 
@@ -380,19 +376,15 @@ bool ExtendedStorage::addNotebook(const Notebook::Ptr &nb, bool signal)
         return false;
     }
 
-    if (!calendar()->hasValidNotebook(nb->uid())
-        && !calendar()->addNotebook(nb->uid(), nb->isVisible())) {
-        qCWarning(lcMkcal) << "cannot add notebook" << nb->uid() << "to calendar";
-        return false;
-    }
-
-    if (!modifyNotebook(nb, DBInsert, signal)) {
-        if (!calendar()->deleteNotebook(nb->uid())) {
-            qCWarning(lcMkcal) << "cannot delete notebook" << nb->uid() << "from calendar";
-        }
+    if (!modifyNotebook(nb, DBInsert)) {
         return false;
     }
     d->mNotebooks.insert(nb->uid(), nb);
+
+    if (!calendar()->addNotebook(nb->uid(), nb->isVisible())
+        && !calendar()->updateNotebook(nb->uid(), nb->isVisible())) {
+        qCWarning(lcMkcal) << "notebook" << nb->uid() << "already in calendar";
+    }
 
     return true;
 }
@@ -424,7 +416,7 @@ bool ExtendedStorage::updateNotebook(const Notebook::Ptr &nb)
     return true;
 }
 
-bool ExtendedStorage::deleteNotebook(const Notebook::Ptr &nb, bool onlyMemory)
+bool ExtendedStorage::deleteNotebook(const Notebook::Ptr &nb)
 {
     if (!nb || !d->mNotebooks.contains(nb->uid())) {
         return false;
@@ -435,30 +427,24 @@ bool ExtendedStorage::deleteNotebook(const Notebook::Ptr &nb, bool onlyMemory)
     }
 
     // delete all notebook incidences from calendar
-    if (!onlyMemory) {
-        Incidence::List list;
-        Incidence::List::Iterator it;
-        if (allIncidences(&list, nb->uid())) {
-            qCDebug(lcMkcal) << "deleting" << list.size() << "notes of notebook" << nb->name();
-            for (it = list.begin(); it != list.end(); ++it) {
-                load((*it)->uid(), (*it)->recurrenceId());
-            }
-            for (it = list.begin(); it != list.end(); ++it) {
-                Incidence::Ptr toDelete = calendar()->incidence((*it)->uid(), (*it)->recurrenceId());
+    if (loadNotebookIncidences(nb->uid())) {
+        const Incidence::List list = calendar()->incidences(nb->uid());
+        qCDebug(lcMkcal) << "deleting" << list.size() << "incidences of notebook" << nb->name();
+        for (const Incidence::Ptr &toDelete : list) {
+            if (!toDelete->hasRecurrenceId()
+                || calendar()->incidence(toDelete->uid(), toDelete->recurrenceId()))
                 calendar()->deleteIncidence(toDelete);
-            }
-            if (!list.isEmpty()) {
-                save(ExtendedStorage::PurgeDeleted);
-            }
-        } else {
-            qCWarning(lcMkcal) << "error when loading incidences for notebook" << nb->uid();
-            return false;
         }
+        if (!list.isEmpty()) {
+            save(ExtendedStorage::PurgeDeleted);
+        }
+    } else {
+        qCWarning(lcMkcal) << "error when loading incidences for notebook" << nb->uid();
+        return false;
     }
 
     if (!calendar()->deleteNotebook(nb->uid())) {
-        qCWarning(lcMkcal) << "cannot delete notebook" << nb->uid() << "from calendar";
-        return false;
+        qCWarning(lcMkcal) << "notebook" << nb->uid() << "already deleted from calendar";
     }
 
     d->mNotebooks.remove(nb->uid());
@@ -498,11 +484,7 @@ bool ExtendedStorage::setDefaultNotebook(const Notebook::Ptr &nb)
 
 Notebook::Ptr ExtendedStorage::defaultNotebook()
 {
-    if (d->mDefaultNotebook) {
-        return d->mDefaultNotebook;
-    } else {
-        return Notebook::Ptr();
-    }
+    return d->mDefaultNotebook;
 }
 
 Notebook::List ExtendedStorage::notebooks()
@@ -512,11 +494,7 @@ Notebook::List ExtendedStorage::notebooks()
 
 Notebook::Ptr ExtendedStorage::notebook(const QString &uid)
 {
-    if (d->mNotebooks.contains(uid)) {
-        return d->mNotebooks.value(uid);
-    } else {
-        return Notebook::Ptr();
-    }
+    return d->mNotebooks.value(uid);
 }
 
 void ExtendedStorage::setValidateNotebooks(bool validateNotebooks)
@@ -698,25 +676,21 @@ Incidence::Ptr ExtendedStorage::checkAlarm(const QString &uid, const QString &re
 
 Notebook::Ptr ExtendedStorage::createDefaultNotebook(QString name, QString color)
 {
-    QString uid;
-#ifdef MKCAL_FOR_MEEGO
-    if (name.isEmpty()) {
-        MLocale locale;
-        locale.installTrCatalog("calendar");
-        MLocale::setDefault(locale);
-        name = qtTrId("qtn_caln_personal_caln");
-    }
-    if (color.isEmpty())
-        color = "#63B33B";
-    uid = "11111111-2222-3333-4444-555555555555";
-#else
+    // Could use QUuid::WithoutBraces when moving to Qt5.11.
+    const QString uid(QUuid::createUuid().toString());
     if (name.isEmpty())
         name = "Default";
     if (color.isEmpty())
         color = "#0000FF";
-#endif
-    Notebook::Ptr nbDefault = Notebook::Ptr(new Notebook(uid, name, QString(), color, false, true, false, false, true));
-    addNotebook(nbDefault, false);
+    Notebook::Ptr nbDefault(new Notebook(uid.mid(1, uid.length() - 2), name, QString(), color,
+                                         false, true, false, false, true));
+    if (modifyNotebook(nbDefault, DBInsert, false)) {
+        d->mNotebooks.insert(nbDefault->uid(), nbDefault);
+        if (!calendar()->addNotebook(nbDefault->uid(), nbDefault->isVisible())
+            && !calendar()->updateNotebook(nbDefault->uid(), nbDefault->isVisible())) {
+            qCWarning(lcMkcal) << "notebook" << nbDefault->uid() << "already in calendar";
+        }
+    }
     setDefaultNotebook(nbDefault);
     return nbDefault;
 }

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -666,7 +666,6 @@ public:
 
 protected:
     virtual bool loadNotebooks() = 0;
-    virtual bool reloadNotebooks() = 0;
     virtual bool modifyNotebook(const Notebook::Ptr &nb, DBOperation dbop,
                                 bool signal = true) = 0;
 

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -535,13 +535,12 @@ public:
       Operation is executed immediately into storage, @see modifyNotebook().
 
       @param nb notebook
-      @param signal for modifynotebook. Default true, false only when database is initialized
       @return true if operation was successful; false otherwise.
 
       @note if the Notebook doesn't have a uid that is a valid UUID a new one will
       be generated on insertion.
     */
-    bool addNotebook(const Notebook::Ptr &nb, bool signal = true);
+    bool addNotebook(const Notebook::Ptr &nb);
 
     /**
       Update notebook parameters.
@@ -557,11 +556,9 @@ public:
       Operation is executed immediately into storage, @see modifyNotebook().
 
       @param nb notebook
-      @param onlyMemory. If true deleting notebooks only from memory but not from database.
-      Default false, true only when notebooks are reloaded from database
       @return true if delete was successful; false otherwise.
     */
-    bool deleteNotebook(const Notebook::Ptr &nb, bool onlyMemory = false);
+    bool deleteNotebook(const Notebook::Ptr &nb);
 
     /**
       setDefaultNotebook to the storage.

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -1873,23 +1873,6 @@ error:
     return false;
 }
 
-bool SqliteStorage::reloadNotebooks()
-{
-    if (!d->mIsOpened) {
-        return false;
-    }
-
-    Notebook::List list = notebooks();
-    Notebook::List::Iterator it = list.begin();
-    d->mIsLoading = true;
-    for (; it != list.end(); it++) {
-        deleteNotebook(*it, true);
-    }
-    d->mIsLoading = false;
-
-    return loadNotebooks();
-}
-
 bool SqliteStorage::modifyNotebook(const Notebook::Ptr &nb, DBOperation dbop, bool signal)
 {
     int rv = 0;
@@ -2048,12 +2031,8 @@ void SqliteStorage::fileChanged(const QString &path)
         d->mPreWatcherDbTime = QDateTime();
         return;
     }
-    clearLoaded();
     if (!d->loadTimezones()) {
         qCWarning(lcMkcal) << "loading timezones failed";
-    }
-    if (!reloadNotebooks()) {
-        qCWarning(lcMkcal) << "loading notebooks failed";
     }
     setModified(path);
     qCDebug(lcMkcal) << path << "has been modified";

--- a/src/sqlitestorage.h
+++ b/src/sqlitestorage.h
@@ -415,7 +415,6 @@ private:
 
 protected:
     bool loadNotebooks();
-    bool reloadNotebooks();
     bool modifyNotebook(const Notebook::Ptr &nb, DBOperation dbop, bool signal = true);
 
 private:

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -55,7 +55,8 @@ void tst_storage::initTestCase()
 void tst_storage::cleanupTestCase()
 {
     mKCal::Notebook::Ptr notebook = m_storage->notebook(NotebookId);
-    m_storage->deleteNotebook(notebook);
+    if (notebook)
+        QVERIFY(m_storage->deleteNotebook(notebook));
 }
 
 void tst_storage::init()
@@ -66,7 +67,8 @@ void tst_storage::init()
 void tst_storage::cleanup()
 {
     mKCal::Notebook::Ptr notebook = m_storage->notebook(NotebookId);
-    m_storage->deleteNotebook(notebook);
+    if (notebook)
+        QVERIFY(m_storage->deleteNotebook(notebook));
 }
 
 void tst_storage::tst_timezone()
@@ -1147,8 +1149,9 @@ void tst_storage::tst_dateCreated()
     }
 
     if (!dateCreated_update.isNull()) {
+        fetchEvent->startUpdates();
         fetchEvent->setCreated(dateCreated_update.toUTC());
-        fetchEvent->updated();
+        fetchEvent->endUpdates();
         m_storage->save();
         reloadDb();
 


### PR DESCRIPTION
@pvuorela, this is another API break :/ I'm sorry. In my opinion these optional arguments from these two methods can be quite detrimental to the API consistency and make the code refactoring difficult by creating several internal different code paths for the same call. In addition, the `onlyMemory` argument from deleteNotebook() is dangerous by leaving orphaned incidences in the database if missused. The `signal` argument from addNotebook was used only during initialisation to avoid too many signaling. This can be achieved by calling the modifyNotebook() directly.

Hopefully this is not breaking any client code… What do you think ?