### PR TITLE
[mkcal] Correct tst_load to work on existing DB.

### DIFF
--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -502,7 +502,13 @@ bool ExtendedStorage::deleteNotebook(const Notebook::Ptr &nb)
         return false;
     }
 
-    // delete all notebook incidences from calendar
+    // purge all notebook incidences from storage
+    Incidence::List deleted;
+    deletedIncidences(&deleted, QDateTime(), nb->uid());
+    qCDebug(lcMkcal) << "purging" << deleted.count() << "incidences of notebook" << nb->name();
+    if (!deleted.isEmpty() && !purgeDeletedIncidences(deleted)) {
+        qCWarning(lcMkcal) << "error when purging deleted incidences from notebook" << nb->uid();
+    }
     if (loadNotebookIncidences(nb->uid())) {
         const Incidence::List list = calendar()->incidences(nb->uid());
         qCDebug(lcMkcal) << "deleting" << list.size() << "incidences of notebook" << nb->name();

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -507,8 +507,14 @@ bool ExtendedStorage::deleteNotebook(const Notebook::Ptr &nb)
         const Incidence::List list = calendar()->incidences(nb->uid());
         qCDebug(lcMkcal) << "deleting" << list.size() << "incidences of notebook" << nb->name();
         for (const Incidence::Ptr &toDelete : list) {
-            if (!toDelete->hasRecurrenceId()
-                || calendar()->incidence(toDelete->uid(), toDelete->recurrenceId()))
+            // Need to test the existence of toDelete inside the calendar here,
+            // because KCalendarCore::Calendar::incidences(nbuid) is returning
+            // all incidences associated to nbuid, even those that have been
+            // deleted already.
+            // In addition, Calendar::deleteIncidence() is also deleting all exceptions
+            // of a recurring event, so exceptions may have been already removed and
+            // their existence should be checked to avoid warnings.
+            if (calendar()->incidence(toDelete->uid(), toDelete->recurrenceId()))
                 calendar()->deleteIncidence(toDelete);
         }
         if (!list.isEmpty()) {

--- a/src/sqliteformat.cpp
+++ b/src/sqliteformat.cpp
@@ -381,7 +381,10 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
 
     if (dbop == DBDelete || dbop == DBMarkDeleted || dbop == DBUpdate) {
         rowid = d->selectRowId(incidence);
-        if (!rowid) {
+        if (!rowid && dbop == DBDelete) {
+            // Already deleted.
+            return true;
+        } else if (!rowid) {
             qCWarning(lcMkcal) << "failed to select rowid of incidence" << incidence->uid() << incidence->recurrenceId();
             goto error;
         }

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -1261,7 +1261,7 @@ void tst_storage::tst_deleted()
 {
     mKCal::Notebook::Ptr notebook =
         mKCal::Notebook::Ptr(new mKCal::Notebook("123456789-deletion",
-                                                 "test notebook",
+                                                 "test notebook for deletion",
                                                  QLatin1String(""),
                                                  "#001122",
                                                  false, // Not shared.
@@ -1358,6 +1358,23 @@ void tst_storage::tst_deleted()
     deleted.clear();
     QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(-2), notebook->uid()));
     QCOMPARE(deleted.length(), 0);
+
+    // Test notebook deletion (with non-purged deleted incidences)
+    QVERIFY(m_calendar->deleteIncidence(fetchEvent3));
+    QVERIFY(m_storage->save());
+    reloadDb();
+    deleted.clear();
+    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime(), notebook->uid()));
+    QCOMPARE(deleted.length(), 1);
+    QVERIFY(m_storage->deleteNotebook(m_storage->notebook(notebook->uid())));
+    reloadDb();
+    QVERIFY(m_storage->notebook(notebook->uid()).isNull());
+    deleted.clear();
+    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime(), notebook->uid()));
+    QVERIFY(deleted.isEmpty());
+    KCalendarCore::Incidence::List incidences;
+    QVERIFY(m_storage->allIncidences(&incidences, notebook->uid()));
+    QVERIFY(incidences.isEmpty());
 }
 
 // Accessor check for modified incidences.


### PR DESCRIPTION
Remove also the warning when purging an already deleted incidence.

Ensure that incidence exists before deletion in notebook delete function.

@pvuorela, following your remark when merging #19, I'm modifying a bit the `tst_load` to ensure that it can run on an existing DB without default notebook. Doing such created some warnings as mentioned above, so I'm also fixing them. What do you think ?