### PR TITLE
[mkcal] Make ExtendedStorage dependency on base KCalendarCore::Calendar.

### DIFF
--- a/src/extendedcalendar.cpp
+++ b/src/extendedcalendar.cpp
@@ -237,17 +237,7 @@ bool ExtendedCalendar::deleteIncidence(const Incidence::Ptr &incidence)
 
 bool ExtendedCalendar::addEvent(const Event::Ptr &aEvent)
 {
-    return addEvent(aEvent, defaultNotebook());
-}
-
-bool ExtendedCalendar::addEvent(const Event::Ptr &aEvent, const QString &notebookUid)
-{
     if (!aEvent) {
-        return false;
-    }
-
-    if (notebookUid.isEmpty()) {
-        qCWarning(lcMkcal) << "ExtendedCalendar::addEvent(): NotebookUid empty";
         return false;
     }
 
@@ -261,7 +251,16 @@ bool ExtendedCalendar::addEvent(const Event::Ptr &aEvent, const QString &noteboo
 
     if (MemoryCalendar::addIncidence(aEvent)) {
         d->addIncidenceToLists(aEvent);
-        return setNotebook(aEvent, notebookUid);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool ExtendedCalendar::addEvent(const Event::Ptr &aEvent, const QString &notebookUid)
+{
+    if (addEvent(aEvent)) {
+        return setNotebook(aEvent, notebookUid.isEmpty() ? defaultNotebook() : notebookUid);
     } else {
         return false;
     }
@@ -270,7 +269,6 @@ bool ExtendedCalendar::addEvent(const Event::Ptr &aEvent, const QString &noteboo
 bool ExtendedCalendar::deleteEvent(const Event::Ptr &event)
 {
     if (MemoryCalendar::deleteIncidence(event)) {
-        event->unRegisterObserver(this);
         d->removeIncidenceFromLists(event);
         return true;
     } else {
@@ -280,17 +278,7 @@ bool ExtendedCalendar::deleteEvent(const Event::Ptr &event)
 
 bool ExtendedCalendar::addTodo(const Todo::Ptr &aTodo)
 {
-    return addTodo(aTodo, defaultNotebook());
-}
-
-bool ExtendedCalendar::addTodo(const Todo::Ptr &aTodo, const QString &notebookUid)
-{
     if (!aTodo) {
-        return false;
-    }
-
-    if (notebookUid.isEmpty()) {
-        qCWarning(lcMkcal) << "ExtendedCalendar::addTodo(): NotebookUid empty";
         return false;
     }
 
@@ -311,7 +299,16 @@ bool ExtendedCalendar::addTodo(const Todo::Ptr &aTodo, const QString &notebookUi
 
     if (MemoryCalendar::addIncidence(aTodo)) {
         d->addIncidenceToLists(aTodo);
-        return setNotebook(aTodo, notebookUid);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool ExtendedCalendar::addTodo(const Todo::Ptr &aTodo, const QString &notebookUid)
+{
+    if (addTodo(aTodo)) {
+        return setNotebook(aTodo, notebookUid.isEmpty() ? defaultNotebook() : notebookUid);
     } else {
         return false;
     }
@@ -320,7 +317,6 @@ bool ExtendedCalendar::addTodo(const Todo::Ptr &aTodo, const QString &notebookUi
 bool ExtendedCalendar::deleteTodo(const Todo::Ptr &todo)
 {
     if (MemoryCalendar::deleteIncidence(todo)) {
-        todo->unRegisterObserver(this);
         d->removeIncidenceFromLists(todo);
         return true;
     } else {
@@ -469,17 +465,7 @@ QDate ExtendedCalendar::previousEventsDate(const QDate &date, const QTimeZone &t
 
 bool ExtendedCalendar::addJournal(const Journal::Ptr &aJournal)
 {
-    return addJournal(aJournal, defaultNotebook());
-}
-
-bool ExtendedCalendar::addJournal(const Journal::Ptr &aJournal, const QString &notebookUid)
-{
     if (!aJournal) {
-        return false;
-    }
-
-    if (notebookUid.isEmpty()) {
-        qCWarning(lcMkcal) << "ExtendedCalendar::addJournal(): NotebookUid empty";
         return false;
     }
 
@@ -500,7 +486,16 @@ bool ExtendedCalendar::addJournal(const Journal::Ptr &aJournal, const QString &n
 
     if (MemoryCalendar::addIncidence(aJournal)) {
         d->addIncidenceToLists(aJournal);
-        return setNotebook(aJournal, notebookUid);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool ExtendedCalendar::addJournal(const Journal::Ptr &aJournal, const QString &notebookUid)
+{
+    if (addJournal(aJournal)) {
+        return setNotebook(aJournal, notebookUid.isEmpty() ? defaultNotebook() : notebookUid);
     } else {
         return false;
     }
@@ -509,7 +504,6 @@ bool ExtendedCalendar::addJournal(const Journal::Ptr &aJournal, const QString &n
 bool ExtendedCalendar::deleteJournal(const Journal::Ptr &journal)
 {
     if (MemoryCalendar::deleteIncidence(journal)) {
-        journal->unRegisterObserver(this);
         d->removeIncidenceFromLists(journal);
         return true;
     } else {

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -137,7 +137,7 @@ public:
 };
 //@endcond
 
-ExtendedStorage::ExtendedStorage(const ExtendedCalendar::Ptr &cal, bool validateNotebooks)
+ExtendedStorage::ExtendedStorage(const Calendar::Ptr &cal, bool validateNotebooks)
     : CalStorage(cal),
       d(new ExtendedStorage::Private(validateNotebooks))
 {

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -32,16 +32,11 @@
 #define MKCAL_EXTENDEDSTORAGE_H
 
 #include "mkcal_export.h"
-#include "extendedcalendar.h"
 #include "extendedstorageobserver.h"
 #include "notebook.h"
 
 #include <KCalendarCore/CalStorage>
 #include <KCalendarCore/Calendar>
-
-namespace KCalendarCore {
-class Incidence;
-}
 
 class MkcalTool;
 class tst_load;
@@ -102,7 +97,7 @@ public:
       cannot change. It is possible to do so through the API, but the internal
       hash tables will not be updated and hence the changes will not be tracked.
     */
-    explicit ExtendedStorage(const ExtendedCalendar::Ptr &cal, bool validateNotebooks = true);
+    explicit ExtendedStorage(const KCalendarCore::Calendar::Ptr &cal, bool validateNotebooks = true);
 
     /**
       Destructor.

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -97,7 +97,7 @@ static const char *createStatements[] =
 class mKCal::SqliteStorage::Private
 {
 public:
-    Private(const ExtendedCalendar::Ptr &calendar, SqliteStorage *storage,
+    Private(const Calendar::Ptr &calendar, SqliteStorage *storage,
             const QString &databaseName
            )
         : mCalendar(calendar),
@@ -118,7 +118,7 @@ public:
     {
     }
 
-    ExtendedCalendar::Ptr mCalendar;
+    Calendar::Ptr mCalendar;
     SqliteStorage *mStorage;
     QString mDatabaseName;
 #ifdef Q_OS_UNIX
@@ -154,7 +154,7 @@ public:
 };
 //@endcond
 
-SqliteStorage::SqliteStorage(const ExtendedCalendar::Ptr &cal, const QString &databaseName,
+SqliteStorage::SqliteStorage(const Calendar::Ptr &cal, const QString &databaseName,
                              bool validateNotebooks)
     : ExtendedStorage(cal, validateNotebooks),
       d(new Private(cal, this, databaseName))
@@ -194,7 +194,7 @@ static QString defaultLocation()
     return dbFile;
 }
 
-SqliteStorage::SqliteStorage(const ExtendedCalendar::Ptr &cal, bool validateNotebooks)
+SqliteStorage::SqliteStorage(const Calendar::Ptr &cal, bool validateNotebooks)
     : SqliteStorage(cal, defaultLocation(), validateNotebooks)
 {
 }
@@ -1196,7 +1196,8 @@ bool SqliteStorage::Private::addIncidence(const Incidence::Ptr &incidence, const
             }
         }
     }
-    if (added && !mCalendar->addIncidence(incidence, notebookUid)) {
+    if (added && (!mCalendar->addIncidence(incidence)
+                  || !mCalendar->setNotebook(incidence, notebookUid))) {
         added = false;
         qCWarning(lcMkcal) << "cannot add incidence" << incidence->uid() << "to notebook" << notebookUid;
     }

--- a/src/sqlitestorage.h
+++ b/src/sqlitestorage.h
@@ -65,7 +65,7 @@ public:
       @param validateNotebooks set to true for saving only those incidences
              that belong to an existing notebook of this storage
     */
-    explicit SqliteStorage(const ExtendedCalendar::Ptr &cal,
+    explicit SqliteStorage(const KCalendarCore::Calendar::Ptr &cal,
                            const QString &databaseName,
                            bool validateNotebooks = true);
 
@@ -78,7 +78,7 @@ public:
       @param validateNotebooks set to true for saving only those incidences
              that belong to an existing notebook of this storage
     */
-    explicit SqliteStorage(const ExtendedCalendar::Ptr &cal,
+    explicit SqliteStorage(const KCalendarCore::Calendar::Ptr &cal,
                            bool validateNotebooks = true);
 
     /**

--- a/tests/tst_perf.cpp
+++ b/tests/tst_perf.cpp
@@ -23,6 +23,7 @@
 #include <QTemporaryFile>
 
 #include "tst_perf.h"
+#include "extendedcalendar.h"
 #include "sqlitestorage.h"
 
 tst_perf::tst_perf(QObject *parent)
@@ -92,6 +93,7 @@ void tst_perf::tst_save()
             i += 1;
         }
         QVERIFY(m_storage->calendar()->addIncidence(event));
+        QVERIFY(m_storage->calendar()->setNotebook(event, m_storage->defaultNotebook()->uid()));
     }
     QCOMPARE(m_storage->calendar()->rawEvents().count(), N_EVENTS);
     QVERIFY(m_storage->save());

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -1544,7 +1544,7 @@ void tst_storage::tst_icalAllDay()
                        "VERSION:2.0\n") + vEvent +
         QStringLiteral("\nEND:VCALENDAR");
     KCalendarCore::ICalFormat format;
-    QVERIFY(format.fromString(m_calendar, icsData));
+    QVERIFY(format.fromString(m_calendar, icsData, false, m_calendar->defaultNotebook()));
     KCalendarCore::Event::Ptr event = m_calendar->event(uid);
     QVERIFY(event);
     QCOMPARE(event->allDay(), allDay);
@@ -1870,7 +1870,8 @@ void tst_storage::tst_populateFromIcsData()
     event->setDtStart(QDateTime(QDate(2021, 9, 23), QTime(15, 29)));
 
     KCalendarCore::ICalFormat icalFormat;
-    QVERIFY(icalFormat.fromRawString(m_calendar, icalFormat.toICalString(event).toUtf8()));
+    QVERIFY(icalFormat.fromRawString(m_calendar, icalFormat.toICalString(event).toUtf8(),
+                                     false, m_calendar->defaultNotebook()));
     QVERIFY(m_calendar->incidence(event->uid()));
     QVERIFY(m_storage->save());
 
@@ -1878,7 +1879,8 @@ void tst_storage::tst_populateFromIcsData()
     QVERIFY(m_calendar->incidence(event->uid()));
 
     event->setRevision(event->revision() + 1);
-    QVERIFY(icalFormat.fromRawString(m_calendar, icalFormat.toICalString(event).toUtf8()));
+    QVERIFY(icalFormat.fromRawString(m_calendar, icalFormat.toICalString(event).toUtf8(),
+                                     false, m_calendar->defaultNotebook()));
     QVERIFY(m_calendar->incidence(event->uid()));
     QCOMPARE(m_calendar->incidence(event->uid())->revision(), event->revision());
     m_storage->save();
@@ -2033,7 +2035,7 @@ void tst_storage::tst_storageObserver()
     QVERIFY(!modified.wait(200)); // Even after 200ms the modified signal is not emitted.
 
     KCalendarCore::Event::Ptr event(new KCalendarCore::Event);
-    QVERIFY(m_calendar->addIncidence(event));
+    QVERIFY(m_calendar->addIncidence(event, {}));
     QVERIFY(updated.isEmpty());
     m_storage->save();
     QCOMPARE(updated.count(), 1);
@@ -2078,7 +2080,7 @@ void tst_storage::tst_storageObserver()
     KCalendarCore::Event::Ptr event2(new KCalendarCore::Event);
     event2->setSummary(QString::fromLatin1("New event added externally"));
     event2->setDtStart(QDateTime(QDate(2022, 3, 9), QTime(11, 46)));
-    QVERIFY(calendar->addEvent(event2));
+    QVERIFY(calendar->addEvent(event2, {}));
     QVERIFY(storage->save());
     QVERIFY(modified.wait());
     QVERIFY(updated.isEmpty());


### PR DESCRIPTION
This would allow to later create new calendar based on SQLite
backend, without inheriting from ExtendedCalendar, but only
based on upstream KCalendarCore::Calendar.

This is a follow-up of #23, with only the MR making the switch in ExtendedStorage from ExtendedCalendar to KCalendarCode::Calendar. For the tests to pass, it requires to compile KCalendarCore with https://invent.kde.org/frameworks/kcalendarcore/-/merge_requests/98 for the moment.

It is also introducing the following changes in ExtendedCalendar though:
- `::addEvent(Incidence::Ptr)` is now adding an incidence without specifying a notebook (previously it was assigning the added event to the default one).
- `::addEvent(Incidence::Ptr, QString)` is now using the default notebook when the QString argument is empty (previously, it was failing with a warning).

The rational for the change is the following: upstream has no support for `addEvent()` with two arguments, it is first adding the event and then calling `setNotebook()`. So we need a way to add incidences without notebook. That's the role of the overloaded method. While the new 2 arguments method is dedicated for event with a notebook, defaulting if necessary.

I've modified `tst_load` to mix ExtendedCalendar and KCalendarCore::Calendar as calendar support for a SqliteStorqge backend. With an upstream calendar backend, we see that we have no other choice than adding calls to `setNotebook()`.

Hopefully these changes will not affect too much real code since we use the 2 arguments method in almost every cases. But the case where we were expecting the default calendar, we will need to add a call to `setNotebook()`, or use the 2 argument variant with an empty second argument.

@pvuorela, what do you think ? This may have quite unexpected consequences, but maybe the change is worth to drop the ExtendedCalendar dependency.