### PR TITLE
[mkcal] Add a special case for notebook change in save.

### DIFF
--- a/src/sqliteformat.cpp
+++ b/src/sqliteformat.cpp
@@ -124,7 +124,7 @@ public:
 
     bool updateMetadata(int transactionId);
     bool selectCustomproperties(Incidence::Ptr &incidence, int rowid);
-    int selectRowId(Incidence::Ptr incidence);
+    int selectRowId(Incidence::Ptr incidence, QString *notebookUid);
     bool selectRecursives(Incidence::Ptr &incidence, int rowid);
     bool selectAlarms(Incidence::Ptr &incidence, int rowid);
     bool selectAttendees(Incidence::Ptr &incidence, int rowid);
@@ -379,15 +379,38 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
     sqlite3_int64 secs;
     int rowid = 0;
     sqlite3_stmt *stmt1;
+    QString oldNotebook;
 
     if (dbop == DBDelete || dbop == DBMarkDeleted || dbop == DBUpdate) {
-        rowid = d->selectRowId(incidence);
+        rowid = d->selectRowId(incidence, &oldNotebook);
         if (!rowid && dbop == DBDelete) {
             // Already deleted.
             return true;
         } else if (!rowid) {
             qCWarning(lcMkcal) << "failed to select rowid of incidence" << incidence->uid() << incidence->recurrenceId();
-            goto error;
+            return false;
+        }
+    }
+
+    if (dbop == DBInsert || (oldNotebook != nbook && dbop == DBUpdate)) {
+        qCDebug(lcMkcal) << "purge all previously deleted components before"
+            "inserting or changing notebook for" << incidence->uid();
+        if (!purgeDeletedComponents(incidence)) {
+            qCWarning(lcMkcal) << "cannot purge deleted components on insert or notebook change.";
+            return false;
+        }
+    }
+
+    if (oldNotebook != nbook && dbop == DBUpdate) {
+        qCDebug(lcMkcal) << "changing notebook from" << oldNotebook << "to" << nbook;
+        if (!modifyComponents(incidence, oldNotebook, DBMarkDeleted)) {
+            qCWarning(lcMkcal) << "failed to mark incidence" << incidence->uid()
+                               << incidence->recurrenceId() << "as deleted for notebook change";
+            return false;
+        } else {
+            // Incidence belonging to the old notebook has been marked
+            // as deleted. Now insert incidence as new within the new notebook.
+            dbop = DBInsert;
         }
     }
 
@@ -434,7 +457,7 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
         break;
     default:
         qCWarning(lcMkcal) << "unknown DB operation" << dbop;
-        goto error;
+        return false;
     }
 
     if (dbop == DBInsert || dbop == DBUpdate) {
@@ -455,7 +478,8 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
             type = "FreeBusy";
             break;
         case Incidence::TypeUnknown:
-            goto error;
+            qCWarning(lcMkcal) << "unknown incidence type" << incidence->type();
+            return false;
         }
         SL3_bind_text(stmt1, index, type.constData(), type.length(), SQLITE_STATIC);   // NOTE
 
@@ -637,6 +661,7 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
     return true;
 
 error:
+    qCWarning(lcMkcal) << "Sqlite error:" << sqlite3_errmsg(d->mDatabase);
     return false;
 }
 
@@ -1610,7 +1635,7 @@ error:
 }
 
 //@cond PRIVATE
-int SqliteFormat::Private::selectRowId(Incidence::Ptr incidence)
+int SqliteFormat::Private::selectRowId(Incidence::Ptr incidence, QString *notebookUid)
 {
     int rv = 0;
     int index = 1;
@@ -1622,8 +1647,8 @@ int SqliteFormat::Private::selectRowId(Incidence::Ptr incidence)
     qint64 secsRecurId;
     int rowid = 0;
 
-    query = SELECT_ROWID_FROM_COMPONENTS_BY_UID_AND_RECURID;
-    qsize = sizeof(SELECT_ROWID_FROM_COMPONENTS_BY_UID_AND_RECURID);
+    query = SELECT_ROWID_NOTEBOOKID_FROM_COMPONENTS_BY_UID_AND_RECURID;
+    qsize = sizeof(SELECT_ROWID_NOTEBOOKID_FROM_COMPONENTS_BY_UID_AND_RECURID);
 
     SL3_prepare_v2(mDatabase, query, qsize, &stmt, NULL);
     u = incidence->uid().toUtf8();
@@ -1643,10 +1668,12 @@ int SqliteFormat::Private::selectRowId(Incidence::Ptr incidence)
 
     if (rv == SQLITE_ROW) {
         rowid = sqlite3_column_int(stmt, 0);
+        if (notebookUid) {
+            *notebookUid = QString::fromUtf8((const char *)sqlite3_column_text(stmt, 1));
+        }
     }
 
 error:
-    sqlite3_reset(stmt);
     sqlite3_finalize(stmt);
 
     return rowid;

--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -423,8 +423,8 @@ private:
 "select * from Components where UID=? and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_NOTEBOOKUID \
 "select * from Components where Notebook=? and DateDeleted=0"
-#define SELECT_ROWID_FROM_COMPONENTS_BY_UID_AND_RECURID \
-"select ComponentId from Components where UID=? and RecurId=? and DateDeleted=0"
+#define SELECT_ROWID_NOTEBOOKID_FROM_COMPONENTS_BY_UID_AND_RECURID \
+"select ComponentId, notebook from Components where UID=? and RecurId=? and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_UNCOMPLETED_TODOS \
 "select * from Components where Type='Todo' and DateCompleted=0 and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_COMPLETED_TODOS_AND_DATE \

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -1413,12 +1413,6 @@ bool SqliteStorage::Private::saveIncidences(QHash<QString, Incidence::Ptr> &list
         if (!mFormat->modifyComponents(*it, notebookUid, dbop)) {
             qCWarning(lcMkcal) << sqlite3_errmsg(mDatabase) << "for incidence" << (*it)->uid();
             errors++;
-        } else  if (dbop == DBInsert) {
-            // Don't leave deleted events with the same UID/recID.
-            if (!mFormat->purgeDeletedComponents(*it)) {
-                qCWarning(lcMkcal) << "cannot purge deleted components on insertion.";
-                errors += 1;
-            }
         }
     }
 

--- a/tests/tst_storage.h
+++ b/tests/tst_storage.h
@@ -64,6 +64,7 @@ private slots:
     void tst_deleted();
     void tst_modified();
     void tst_inserted();
+    void tst_changeNotebook();
     void tst_icalAllDay_data();
     void tst_icalAllDay();
     void tst_deleteAllEvents();


### PR DESCRIPTION
Handle notebook change as a deletion in the previous notebook,
and an addition in the new one. Like that any sync on the
previous notebook can propagate the deletion.

@pvuorela , from our discussion yesterday, I think I've found a low-level way to properly treat the notebook change. I've added a test to demonstrate it. It should work also for recurring events with exceptions, but there is a bug upstream, see https://invent.kde.org/frameworks/kcalendarcore/-/merge_requests/99.

When a downstream code is calling `calendar->setNotebook()` on an existing incidence, the calendar is calling `calendarIncidenceChanged()` for every observers. Then, on next `save()` call this incidence is sent to `SqliteFormat::modifyComponent()` with a `DBUpdate` operation. The idea of the patch is to read the old notebook value in case of an update operation, in the same SQL request than the one fetching the rowid. If the notebook differs, we substitute the update operation with a mark as deleted on the incidence followed by an insert operation on the same incidence but with a different notebook id.

If you think it's ok, I will have to update the bindings to replace the current delete + add code with the proper `calendar->setNotebook()` one. And also reenable all the signals that a notebook has been changed and reenable the action in the UI. But first things first, what do you think of this low level patch ?