### PR TITLE
[mkcal] Fix tst_load unit test failure. JB#57856

### DIFF
--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -201,8 +201,12 @@ bool ExtendedStorage::getLoadDates(const QDate &start, const QDate &end,
         return false;
     }
 
-    loadStart->setTimeZone(calendar()->timeZone());
-    loadEnd->setTimeZone(calendar()->timeZone());
+    if (loadStart->isValid()) {
+        loadStart->setTimeZone(calendar()->timeZone());
+    }
+    if (loadEnd->isValid()) {
+        loadEnd->setTimeZone(calendar()->timeZone());
+    }
 
     qCDebug(lcMkcal) << "get load dates" << start << end << *loadStart << *loadEnd;
 


### PR DESCRIPTION
QCOMPARE() was failing on comparing invalid QDateTimes between getLoadDates()
returned and separately created. Avoid timezones on such not to confuse
any comparisons.

@Tomin1 @dcaliste 