### PR TITLE
[mkcal] Load rdates-only components as recurring events.

### DIFF
--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -408,9 +408,9 @@ private:
 #define SELECT_COMPONENTS_BY_PLAIN \
 "select * from Components where DateStart=0 and DateEndDue=0 and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_RECURSIVE \
-"select * from components where ((ComponentId in (select DISTINCT ComponentId from recursive)) or (RecurId!=0)) and DateDeleted=0"
+"select * from Components where ((ComponentId in (select DISTINCT ComponentId from Recursive)) or (ComponentId in (select DISTINCT ComponentId from Rdates)) or (RecurId!=0)) and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_ATTENDEE \
-"select * from components where ComponentId in (select DISTINCT ComponentId from attendee) and DateDeleted=0"
+"select * from Components where ComponentId in (select DISTINCT ComponentId from Attendee) and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_DATE_BOTH \
 "select * from Components where DateStart<? and (DateEndDue>=? or (DateEndDue=0 and DateStart>=?)) and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_DATE_START \

--- a/tests/tst_load.cpp
+++ b/tests/tst_load.cpp
@@ -271,6 +271,12 @@ void tst_load::testByDate()
     KCalendarCore::Event::Ptr event6(new KCalendarCore::Event);
     event6->setDtStart(QDateTime(date.addDays(1), QTime(0, 30), QTimeZone("Europe/Paris")));
     QVERIFY(mStorage->calendar()->addEvent(event6));
+    // Recurring event defined with rdates.
+    KCalendarCore::Event::Ptr event7(new KCalendarCore::Event);
+    event7->setDtStart(QDateTime(date.addDays(-3), QTime(12, 0), Qt::UTC));
+    event7->recurrence()->addRDateTime(QDateTime(date, QTime(9, 0), Qt::UTC));
+    QVERIFY(mStorage->calendar()->addEvent(event7));
+
     QVERIFY(mStorage->save());
     
     ExtendedCalendar::Ptr calendar(new ExtendedCalendar(QTimeZone::utc()));
@@ -285,11 +291,13 @@ void tst_load::testByDate()
     QVERIFY(calendar->incidence(event4->uid()));
     QVERIFY(calendar->incidence(event5->uid()));
     QVERIFY(calendar->incidence(event6->uid()));
-    QCOMPARE(calendar->events().length() - length0, 5);
+    QVERIFY(calendar->incidence(event7->uid()));
+    QCOMPARE(calendar->events().length() - length0, 6);
     QVERIFY(storage->isRecurrenceLoaded());
     QDateTime start, end;
     QVERIFY(!storage->getLoadDates(date, date.addDays(1), &start, &end));
 
+    QVERIFY(mStorage->calendar()->deleteIncidence(event7));
     QVERIFY(mStorage->calendar()->deleteIncidence(event6));
     QVERIFY(mStorage->calendar()->deleteIncidence(event5));
     QVERIFY(mStorage->calendar()->deleteIncidence(event4));


### PR DESCRIPTION
Events defined with RDATE only are otherwise not seen
as recurring and are not loaded in a byDate fetch.

@pvuorela, this is fixing https://forum.sailfishos.org/t/bug-in-calendar-app-alarm-to-calendar-entry-correctly-goes-off-but-calendar-entry-is-not-visible-in-the-calendar/10894 In the ICS of the poster, the event is defined with RDATE, starting in January. The events are not showing in the calendar, because, the incidence is actually loaded only when swiping to January, and then the ranges for the other months are already flagged as loaded in nemo-qml-plugin-calendar, so the occurrences for these ranges are not recomputed.

The fact that we also load components with EXDATE only with the patch, is not a real issue in my opinion. In fact such incidences are recurring by definition so they should be loaded. Actually they are already since they will have a rule in recursive table.