### PR TITLE
Rework ExtendedStorage API and service plugin API to remove any Notebook::Ptr

### DIFF
--- a/plugins/defaultinvitationplugin/defaultinvitationplugin.cpp
+++ b/plugins/defaultinvitationplugin/defaultinvitationplugin.cpp
@@ -332,27 +332,27 @@ bool DefaultInvitationPlugin::multiCalendar() const
     return false;
 }
 
-QString DefaultInvitationPlugin::emailAddress(const mKCal::Notebook::Ptr &notebook)
+QString DefaultInvitationPlugin::emailAddress(const mKCal::Notebook &notebook)
 {
-    if (notebook.isNull()) {
-        qCritical() << "Invalid notebook";
+    if (!notebook.isValid()) {
+        qWarning() << "Invalid notebook";
         return QString();
     }
-    if (notebook->account().isEmpty()) {
+    if (notebook.account().isEmpty()) {
         // just return quietly, it can be a local notebook
         return QString();
     }
 
-    return d->accountEmailAddress(notebook->account());
+    return d->accountEmailAddress(notebook.account());
 }
 
-QString DefaultInvitationPlugin::displayName(const mKCal::Notebook::Ptr &notebook) const
+QString DefaultInvitationPlugin::displayName(const mKCal::Notebook &notebook) const
 {
     Q_UNUSED(notebook);
     return QString();
 }
 
-bool DefaultInvitationPlugin::downloadAttachment(const mKCal::Notebook::Ptr &notebook, const QString &uri,
+bool DefaultInvitationPlugin::downloadAttachment(const mKCal::Notebook &notebook, const QString &uri,
                                                  const QString &path)
 {
     Q_UNUSED(notebook);
@@ -362,7 +362,7 @@ bool DefaultInvitationPlugin::downloadAttachment(const mKCal::Notebook::Ptr &not
     return false;
 }
 
-bool DefaultInvitationPlugin::deleteAttachment(const mKCal::Notebook::Ptr &notebook, const Incidence::Ptr &incidence,
+bool DefaultInvitationPlugin::deleteAttachment(const mKCal::Notebook &notebook, const Incidence::Ptr &incidence,
                                                const QString &uri)
 {
     Q_UNUSED(notebook);
@@ -372,7 +372,7 @@ bool DefaultInvitationPlugin::deleteAttachment(const mKCal::Notebook::Ptr &noteb
     return false;
 }
 
-bool DefaultInvitationPlugin::shareNotebook(const mKCal::Notebook::Ptr &notebook, const QStringList &sharedWith)
+bool DefaultInvitationPlugin::shareNotebook(const mKCal::Notebook &notebook, const QStringList &sharedWith)
 {
     Q_UNUSED(notebook);
     Q_UNUSED(sharedWith);
@@ -380,7 +380,7 @@ bool DefaultInvitationPlugin::shareNotebook(const mKCal::Notebook::Ptr &notebook
     return false;
 }
 
-QStringList DefaultInvitationPlugin::sharedWith(const mKCal::Notebook::Ptr &notebook)
+QStringList DefaultInvitationPlugin::sharedWith(const mKCal::Notebook &notebook)
 {
     Q_UNUSED(notebook);
     d->mErrorCode = ServiceInterface::ErrorNotSupported;

--- a/plugins/defaultinvitationplugin/defaultinvitationplugin.h
+++ b/plugins/defaultinvitationplugin/defaultinvitationplugin.h
@@ -55,17 +55,17 @@ public:
 
     bool multiCalendar() const;
 
-    QString emailAddress(const mKCal::Notebook::Ptr &notebook);
+    QString emailAddress(const mKCal::Notebook &notebook);
 
-    QString displayName(const mKCal::Notebook::Ptr &notebook) const;
+    QString displayName(const mKCal::Notebook &notebook) const;
 
-    bool downloadAttachment(const mKCal::Notebook::Ptr &notebook, const QString &uri, const QString &path);
+    bool downloadAttachment(const mKCal::Notebook &notebook, const QString &uri, const QString &path);
 
-    bool deleteAttachment(const mKCal::Notebook::Ptr &notebook, const Incidence::Ptr &incidence, const QString &uri);
+    bool deleteAttachment(const mKCal::Notebook &notebook, const Incidence::Ptr &incidence, const QString &uri);
 
-    bool shareNotebook(const mKCal::Notebook::Ptr &notebook, const QStringList &sharedWith);
+    bool shareNotebook(const mKCal::Notebook &notebook, const QStringList &sharedWith);
 
-    QStringList sharedWith(const mKCal::Notebook::Ptr &notebook);
+    QStringList sharedWith(const mKCal::Notebook &notebook);
 
     QString serviceName() const;
 

--- a/src/dummystorage.h
+++ b/src/dummystorage.h
@@ -37,8 +37,7 @@ class MKCAL_EXPORT DummyStorage : public mKCal::ExtendedStorage
 public:
     DummyStorage(const mKCal::ExtendedCalendar::Ptr &cal) : mKCal::ExtendedStorage(cal)
     {
-        mKCal::Notebook::Ptr nb = mKCal::Notebook::Ptr(new mKCal::Notebook("dummy-name",
-                                                                           "dummy-desc"));
+        mKCal::Notebook nb("dummy-name", "dummy-desc");
         bool r;
         r = addNotebook(nb);
         Q_ASSERT(r);

--- a/src/dummystorage.h
+++ b/src/dummystorage.h
@@ -236,7 +236,7 @@ public:
     {
         return true;
     }
-    bool modifyNotebook(const mKCal::Notebook::Ptr &, mKCal::DBOperation)
+    bool modifyNotebook(const mKCal::Notebook &, mKCal::DBOperation)
     {
         return true;
     }

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -422,7 +422,7 @@ bool ExtendedStorage::addNotebook(const Notebook &nb)
         return false;
     }
 
-    if (!modifyNotebook(nb, DBInsert)) {
+    if (!nb.isRunTimeOnly() && !modifyNotebook(nb, DBInsert)) {
         return false;
     }
     d->mNotebooks.insert(nb.uid(), nb);
@@ -441,7 +441,7 @@ bool ExtendedStorage::updateNotebook(const Notebook &nb)
         return false;
     }
 
-    if (!modifyNotebook(nb, DBUpdate)) {
+    if (!nb.isRunTimeOnly() && !modifyNotebook(nb, DBUpdate)) {
         return false;
     }
     d->mNotebooks.insert(nb.uid(), nb);
@@ -450,20 +450,23 @@ bool ExtendedStorage::updateNotebook(const Notebook &nb)
     if (!calendar()->updateNotebook(nb.uid(), nb.isVisible())) {
         qCWarning(lcMkcal) << "cannot update notebook" << nb.uid() << "in calendar";
     }
+
 #if defined(TIMED_SUPPORT)
-    if (wasVisible && !nb.isVisible()) {
-        d->clearAlarms(nb.uid());
-    } else if (!wasVisible && nb.isVisible()) {
-        Incidence::List list;
-        if (allIncidences(&list, nb.uid())) {
-            MemoryCalendar::Ptr calendar(new MemoryCalendar(QTimeZone::utc()));
-            if (calendar->addNotebook(nb.uid(), true)) {
-                for (const Incidence::Ptr &incidence : const_cast<const Incidence::List&>(list)) {
-                    calendar->addIncidence(incidence);
-                    calendar->setNotebook(incidence, nb.uid());
+    if (!nb.isRunTimeOnly()) {
+        if (wasVisible && !nb.isVisible()) {
+            d->clearAlarms(nb.uid());
+        } else if (!wasVisible && nb.isVisible()) {
+            Incidence::List list;
+            if (allIncidences(&list, nb.uid())) {
+                MemoryCalendar::Ptr calendar(new MemoryCalendar(QTimeZone::utc()));
+                if (calendar->addNotebook(nb.uid(), true)) {
+                    for (const Incidence::Ptr &incidence : const_cast<const Incidence::List&>(list)) {
+                        calendar->addIncidence(incidence);
+                        calendar->setNotebook(incidence, nb.uid());
+                    }
                 }
+                d->setAlarms(calendar->incidences(), calendar);
             }
-            d->setAlarms(calendar->incidences(), calendar);
         }
     }
 #endif
@@ -476,38 +479,41 @@ bool ExtendedStorage::deleteNotebook(const QString &nbid)
     if (!d->mNotebooks.contains(nbid)) {
         return true;
     }
+    const Notebook &nb = d->mNotebooks.value(nbid);
 
-    if (!modifyNotebook(d->mNotebooks.value(nbid), DBDelete)) {
+    if (!nb.isRunTimeOnly() && !modifyNotebook(d->mNotebooks.value(nbid), DBDelete)) {
         return false;
     }
 
     // purge all notebook incidences from storage
-    Incidence::List deleted;
-    deletedIncidences(&deleted, QDateTime(), nbid);
-    qCDebug(lcMkcal) << "purging" << deleted.count() << "incidences of notebook" << nbid;
-    if (!deleted.isEmpty() && !purgeDeletedIncidences(deleted)) {
-        qCWarning(lcMkcal) << "error when purging deleted incidences from notebook" << nbid;
-    }
-    if (loadNotebookIncidences(nbid)) {
-        const Incidence::List list = calendar()->incidences(nbid);
-        qCDebug(lcMkcal) << "deleting" << list.size() << "incidences of notebook" << nbid;
-        for (const Incidence::Ptr &toDelete : list) {
-            // Need to test the existence of toDelete inside the calendar here,
-            // because KCalendarCore::Calendar::incidences(nbuid) is returning
-            // all incidences associated to nbuid, even those that have been
-            // deleted already.
-            // In addition, Calendar::deleteIncidence() is also deleting all exceptions
-            // of a recurring event, so exceptions may have been already removed and
-            // their existence should be checked to avoid warnings.
-            if (calendar()->incidence(toDelete->uid(), toDelete->recurrenceId()))
-                calendar()->deleteIncidence(toDelete);
+    if (!nb.isRunTimeOnly()) {
+        Incidence::List deleted;
+        deletedIncidences(&deleted, QDateTime(), nbid);
+        qCDebug(lcMkcal) << "purging" << deleted.count() << "incidences of notebook" << nbid;
+        if (!deleted.isEmpty() && !purgeDeletedIncidences(deleted)) {
+            qCWarning(lcMkcal) << "error when purging deleted incidences from notebook" << nbid;
         }
-        if (!list.isEmpty()) {
-            save(ExtendedStorage::PurgeDeleted);
+        if (loadNotebookIncidences(nbid)) {
+            const Incidence::List list = calendar()->incidences(nbid);
+            qCDebug(lcMkcal) << "deleting" << list.size() << "incidences of notebook" << nbid;
+            for (const Incidence::Ptr &toDelete : list) {
+                // Need to test the existence of toDelete inside the calendar here,
+                // because KCalendarCore::Calendar::incidences(nbuid) is returning
+                // all incidences associated to nbuid, even those that have been
+                // deleted already.
+                // In addition, Calendar::deleteIncidence() is also deleting all exceptions
+                // of a recurring event, so exceptions may have been already removed and
+                // their existence should be checked to avoid warnings.
+                if (calendar()->incidence(toDelete->uid(), toDelete->recurrenceId()))
+                    calendar()->deleteIncidence(toDelete);
+            }
+            if (!list.isEmpty()) {
+                save(ExtendedStorage::PurgeDeleted);
+            }
+        } else {
+            qCWarning(lcMkcal) << "error when loading incidences for notebook" << nbid;
+            return false;
         }
-    } else {
-        qCWarning(lcMkcal) << "error when loading incidences for notebook" << nbid;
-        return false;
     }
 
     if (!calendar()->deleteNotebook(nbid)) {
@@ -569,7 +575,7 @@ bool ExtendedStorage::validateNotebooks() const
     return d->mValidateNotebooks;
 }
 
-bool ExtendedStorage::isValidNotebook(const QString &notebookUid)
+bool ExtendedStorage::isValidNotebook(const QString &notebookUid) const
 {
     const Notebook &nb = notebook(notebookUid);
     if (nb.isValid()) {

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -38,8 +38,6 @@
 #include <KCalendarCore/Calendar>
 using namespace KCalendarCore;
 
-#include <QtCore/QUuid>
-
 #ifdef TIMED_SUPPORT
 # include <timed-qt5/interface.h>
 # include <timed-qt5/event-declarations.h>
@@ -421,12 +419,6 @@ void ExtendedStorage::setUpdated(const KCalendarCore::Incidence::List &added,
 
 bool ExtendedStorage::addNotebook(const Notebook::Ptr &nb)
 {
-    if (nb->uid().length() < 7) {
-        // Cannot accept this id, create better one.
-        QString uid(QUuid::createUuid().toString());
-        nb->setUid(uid.mid(1, uid.length() - 2));
-    }
-
     if (!nb || d->mNotebooks.contains(nb->uid())) {
         return false;
     }
@@ -595,14 +587,9 @@ bool ExtendedStorage::isValidNotebook(const QString &notebookUid)
 
 Notebook::Ptr ExtendedStorage::createDefaultNotebook(QString name, QString color)
 {
-    // Could use QUuid::WithoutBraces when moving to Qt5.11.
-    const QString uid(QUuid::createUuid().toString());
     if (name.isEmpty())
         name = "Default";
-    if (color.isEmpty())
-        color = "#0000FF";
-    Notebook::Ptr nbDefault(new Notebook(uid.mid(1, uid.length() - 2), name, QString(), color,
-                                         false, true, false, false, true));
+    Notebook::Ptr nbDefault(new Notebook(name, QString(), color));
     return setDefaultNotebook(nbDefault) ? nbDefault : Notebook::Ptr();
 }
 

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -431,7 +431,7 @@ bool ExtendedStorage::addNotebook(const Notebook::Ptr &nb)
         return false;
     }
 
-    if (!modifyNotebook(nb, DBInsert)) {
+    if (!modifyNotebook(*nb, DBInsert)) {
         return false;
     }
 
@@ -456,7 +456,7 @@ bool ExtendedStorage::updateNotebook(const Notebook::Ptr &nb)
         qCWarning(lcMkcal) << "cannot update notebook" << nb->uid() << "in calendar";
         return false;
     }
-    if (!modifyNotebook(nb, DBUpdate)) {
+    if (!modifyNotebook(*nb, DBUpdate)) {
         return false;
     }
 
@@ -487,7 +487,7 @@ bool ExtendedStorage::deleteNotebook(const Notebook::Ptr &nb)
         return false;
     }
 
-    if (!modifyNotebook(nb, DBDelete)) {
+    if (!modifyNotebook(*nb, DBDelete)) {
         return false;
     }
 

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -575,24 +575,6 @@ bool ExtendedStorage::validateNotebooks() const
     return d->mValidateNotebooks;
 }
 
-bool ExtendedStorage::isValidNotebook(const QString &notebookUid) const
-{
-    const Notebook &nb = notebook(notebookUid);
-    if (nb.isValid()) {
-        if (nb.isRunTimeOnly() || nb.isReadOnly()) {
-            qCDebug(lcMkcal) << "notebook" << notebookUid << "isRunTimeOnly or isReadOnly";
-            return false;
-        }
-    } else if (validateNotebooks()) {
-        qCDebug(lcMkcal) << "notebook" << notebookUid << "is not valid for this storage";
-        return false;
-    } else if (calendar()->hasValidNotebook(notebookUid)) {
-        qCDebug(lcMkcal) << "notebook" << notebookUid << "is saved by another storage";
-        return false;
-    }
-    return true;
-}
-
 Incidence::Ptr ExtendedStorage::checkAlarm(const QString &uid, const QString &recurrenceId,
                                            bool loadAlways)
 {

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -641,7 +641,7 @@ public:
 
 protected:
     virtual bool loadNotebooks() = 0;
-    virtual bool modifyNotebook(const Notebook::Ptr &nb, DBOperation dbop) = 0;
+    virtual bool modifyNotebook(const Notebook &nb, DBOperation dbop) = 0;
 
     bool getLoadDates(const QDate &start, const QDate &end,
                       QDateTime *loadStart, QDateTime *loadEnd) const;

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -598,15 +598,6 @@ public:
     */
     bool validateNotebooks() const;
 
-    /**
-      Returns true if the given notebook is valid for the storage.
-      That means that storage can load/save incidences on this notebook.
-
-      @param notebookUid notebook uid
-      @return true or false
-    */
-    bool isValidNotebook(const QString &notebookUid) const;
-
     // Alarm Methods //
 
     /**

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -518,34 +518,30 @@ public:
 
     /**
       Add new notebook to the storage.
-      Notebook object is owned by the storage if operation succeeds.
-      Operation is executed immediately into storage, @see modifyNotebook().
+      Operation is executed immediately into storage.
 
       @param nb notebook
       @return true if operation was successful; false otherwise.
-
-      @note if the Notebook doesn't have a uid that is a valid UUID a new one will
-      be generated on insertion.
     */
-    bool addNotebook(const Notebook::Ptr &nb);
+    bool addNotebook(const Notebook &nb);
 
     /**
       Update notebook parameters.
-      Operation is executed immediately into storage, @see modifyNotebook().
+      Operation is executed immediately into storage.
 
       @param nb notebook
       @return true if add was successful; false otherwise.
     */
-    bool updateNotebook(const Notebook::Ptr &nb);
+    bool updateNotebook(const Notebook &nb);
 
     /**
       Delete notebook from storage.
-      Operation is executed immediately into storage, @see modifyNotebook().
+      Operation is executed immediately into storage.
 
-      @param nb notebook
+      @param nbid the id of the notebook to delete
       @return true if delete was successful; false otherwise.
     */
-    bool deleteNotebook(const Notebook::Ptr &nb);
+    bool deleteNotebook(const QString &nbid);
 
     /**
       setDefaultNotebook to the storage.
@@ -553,29 +549,36 @@ public:
       @param nb notebook
       @return true if operation was successful; false otherwise.
     */
-    bool setDefaultNotebook(const Notebook::Ptr &nb);
+    bool setDefaultNotebook(const Notebook &nb);
 
     /**
-      defaultNotebook.
+      defaultNotebookId.
 
-      @return pointer to default notebook.
+      @return the default notebook id, if any.
     */
-    Notebook::Ptr defaultNotebook();
+    QString defaultNotebookId() const;
 
     /**
       Search for notebook.
 
       @param uid notebook uid
-      @return pointer to notebook
+      @return the notebook
     */
-    Notebook::Ptr notebook(const QString &uid);
+    Notebook notebook(const QString &uid) const;
 
     /**
       List all notebooks.
 
       @return list of notebooks
     */
-    Notebook::List notebooks();
+    QList<Notebook> notebooks() const;
+
+    /**
+      containsNotebook.
+
+      @return true if the storage contains the notebook identified by uid.
+    */
+    bool containsNotebook(const QString &uid) const;
 
     /**
       Determine if notebooks should be validated in saves and loads.
@@ -593,7 +596,7 @@ public:
 
       @return true to validate notebooks
     */
-    bool validateNotebooks();
+    bool validateNotebooks() const;
 
     /**
       Returns true if the given notebook is valid for the storage.
@@ -618,17 +621,6 @@ public:
     */
     KCalendarCore::Incidence::Ptr checkAlarm(const QString &uid, const QString &recurrenceId,
                                         bool loadAlways = false);
-
-    /**
-      Creates and sets a default notebook. Usually called for an empty
-      calendar.
-
-      @param name notebook's name, if empty default used
-      @param color notebook's color in format "#FF0042", if empty default used
-      @return pointer to the created notebook
-    */
-    Notebook::Ptr createDefaultNotebook(QString name = QString(),
-                                        QString color = QString());
 
     /**
       Standard trick to add virtuals later.

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -571,15 +571,6 @@ public:
     Notebook::Ptr notebook(const QString &uid);
 
     /**
-      Search for notebook in a list.
-
-      @param list notebook list
-      @param uid notebook uid
-      @return pointer to notebook
-    */
-    Notebook::Ptr notebook(Notebook::List &list, const QString &uid);
-
-    /**
       List all notebooks.
 
       @return list of notebooks

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -605,7 +605,7 @@ public:
       @param notebookUid notebook uid
       @return true or false
     */
-    bool isValidNotebook(const QString &notebookUid);
+    bool isValidNotebook(const QString &notebookUid) const;
 
     // Alarm Methods //
 

--- a/src/notebook.cpp
+++ b/src/notebook.cpp
@@ -212,6 +212,11 @@ bool Notebook::operator==(const Notebook &i2) const
         d->mCreationDate == i2.creationDate();
 }
 
+bool Notebook::isValid() const
+{
+    return !d->mUid.isEmpty();
+}
+
 QString Notebook::uid() const
 {
     return d->mUid;

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -83,12 +83,17 @@ public:
       Constructs an Notebook as a copy of another Notebook object.
       @param n is the Notebook to copy.
     */
-    explicit Notebook(const Notebook &n);
+    Notebook(const Notebook &n);
 
     /**
       Destructor.
     */
     virtual ~Notebook();
+
+    /**
+      Returns if the notebook is valid or null constructed.
+    */
+    bool isValid() const;
 
     /**
       Returns the uid of the notebook.

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -65,7 +65,8 @@ public:
     */
     explicit Notebook();
 
-    explicit Notebook(const QString &name, const QString &description);
+    explicit Notebook(const QString &name, const QString &description,
+                      const QString &color = {});
 
     explicit Notebook(const QString &uid, const QString &name,
                       const QString &description, const QString &color,

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -46,21 +46,21 @@ public:
     /**
       Constructs a new Notebook object.
     */
-    explicit Notebook();
+    Notebook();
 
-    explicit Notebook(const QString &name, const QString &description,
-                      const QString &color = {});
+    Notebook(const QString &name, const QString &description,
+             const QString &color = {});
 
-    explicit Notebook(const QString &uid, const QString &name,
-                      const QString &description, const QString &color,
-                      bool isShared, bool isMaster, bool oviSync,
-                      bool isReadOnly, bool isVisible);
+    Notebook(const QString &uid, const QString &name,
+             const QString &description, const QString &color,
+             bool isShared, bool isMaster, bool isSynced,
+             bool isReadOnly, bool isVisible);
 
-    explicit Notebook(const QString &uid, const QString &name,
-                      const QString &description, const QString &color,
-                      bool isShared, bool isMaster, bool isSynchronized,
-                      bool isReadOnly, bool isVisible, const QString &pluginName,
-                      const QString &account, int attachmentSize);
+    Notebook(const QString &uid, const QString &name,
+             const QString &description, const QString &color,
+             bool isShared, bool isMaster, bool isSynchronized,
+             bool isReadOnly, bool isVisible, const QString &pluginName,
+             const QString &account, int attachmentSize);
 
     /**
       Constructs an Notebook as a copy of another Notebook object.

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -34,8 +34,6 @@
 
 #include <KCalendarCore/Incidence>
 
-#include <QtCore/QList>
-
 namespace mKCal {
 
 /**
@@ -45,21 +43,6 @@ namespace mKCal {
 class MKCAL_EXPORT Notebook
 {
 public:
-    /**
-      A shared pointer to a Notebook object.
-    */
-    typedef QSharedPointer<Notebook> Ptr;
-
-    /**
-      A shared pointer to a non-mutable Notebook.
-    */
-    typedef QSharedPointer<const Notebook> ConstPtr;
-
-    /**
-      List of notebooks.
-    */
-    typedef QList<Ptr> List;
-
     /**
       Constructs a new Notebook object.
     */

--- a/src/servicehandler.cpp
+++ b/src/servicehandler.cpp
@@ -92,11 +92,11 @@ bool ServiceHandlerPrivate::executePlugin(ExecutedPlugin action, const Incidence
     if (!mLoaded)
         loadPlugins();
 
-    Notebook::Ptr accountNotebook;
+    Notebook accountNotebook;
     QString notebookUid;
 
     if (!notebook.isNull()) {
-        accountNotebook = notebook;
+        accountNotebook = *notebook;
         notebookUid = notebook->uid();
     } else {
         notebookUid = calendar->notebook(invitation);
@@ -105,13 +105,13 @@ bool ServiceHandlerPrivate::executePlugin(ExecutedPlugin action, const Incidence
         }
     }
 
-    if (accountNotebook.isNull()) {
+    if (!accountNotebook.isValid()) {
         qCWarning(lcMkcal) << "No notebook available for invitation plugin to use";
         return false;
     }
 
-    QString pluginName = accountNotebook->pluginName();
-    QString accountId = accountNotebook->account() ;
+    QString pluginName = accountNotebook.pluginName();
+    QString accountId = accountNotebook.account() ;
 
     if (pluginName.isEmpty() || !mPlugins.contains(pluginName))
         pluginName = defaultName;

--- a/src/servicehandler.cpp
+++ b/src/servicehandler.cpp
@@ -37,8 +37,7 @@ public:
 
     void loadPlugins();
     bool executePlugin(ExecutedPlugin action, const Incidence::Ptr &invitation, const QString &body,
-                       const ExtendedCalendar::Ptr &calendar, const ExtendedStorage::Ptr &storage,
-                       const Notebook &notebook);
+                       const ExtendedStorage &storage, const QString &notebookUid);
     ServiceInterface *getServicePlugin(const Notebook &notebook, const ExtendedStorage::Ptr &storage);
 
     ServiceHandlerPrivate();
@@ -83,27 +82,22 @@ void ServiceHandlerPrivate::loadPlugins()
 }
 
 bool ServiceHandlerPrivate::executePlugin(ExecutedPlugin action, const Incidence::Ptr &invitation, const QString &body,
-                                          const ExtendedCalendar::Ptr &calendar, const ExtendedStorage::Ptr &storage,
-                                          const Notebook &notebook)
+                                          const ExtendedStorage &storage, const QString &notebookUid)
 {
-    if (storage.isNull() || invitation.isNull() || calendar.isNull())
+    if (invitation.isNull())
         return false;
 
     if (!mLoaded)
         loadPlugins();
 
     Notebook accountNotebook;
-    if (notebook.isValid()) {
-        accountNotebook = notebook;
-    } else {
-        const QString notebookUid = calendar->notebook(invitation);
-        if (storage->isValidNotebook(notebookUid)) {
-            accountNotebook = storage->notebook(notebookUid);
-        }
-        if (!accountNotebook.isValid()) {
-            qCWarning(lcMkcal) << "No notebook available for invitation plugin to use";
-            return false;
-        }
+    const QString notebookUid = calendar.notebook(invitation);
+    if (storage.isValidNotebook(notebookUid)) {
+        accountNotebook = storage.notebook(notebookUid);
+    }
+    if (!accountNotebook.isValid()) {
+        qCWarning(lcMkcal) << "No notebook available for invitation plugin to use";
+        return false;
     }
 
     QString pluginName = accountNotebook.pluginName();
@@ -190,35 +184,23 @@ ServiceHandler::ServiceHandler()
 }
 
 bool ServiceHandler::sendInvitation(const Incidence::Ptr &invitation, const QString &body,
-                                    const ExtendedCalendar::Ptr &calendar, const ExtendedStorage::Ptr &storage,
-                                    const Notebook &notebook)
+                                    const ExtendedStorage &storage, const QString &notebookUid)
 {
-    if (storage.isNull() || invitation.isNull() || calendar.isNull())
-        return false;
-
-    return d->executePlugin(SendInvitation, invitation, body, calendar, storage, notebook);
+    return d->executePlugin(SendInvitation, invitation, body, storage, notebookUid);
 }
 
 
 bool ServiceHandler::sendUpdate(const Incidence::Ptr &invitation, const QString &body,
-                                const ExtendedCalendar::Ptr &calendar, const ExtendedStorage::Ptr &storage,
-                                const Notebook &notebook)
+                                const ExtendedStorage &storage, const QString &notebookUid)
 {
-    if (storage.isNull() || invitation.isNull() || calendar.isNull())
-        return false;
-
-    return d->executePlugin(SendUpdate, invitation, body, calendar, storage, notebook);
+    return d->executePlugin(SendUpdate, invitation, body, storage, notebookUid);
 }
 
 
 bool ServiceHandler::sendResponse(const Incidence::Ptr &invitation, const QString &body,
-                                  const ExtendedCalendar::Ptr &calendar, const ExtendedStorage::Ptr &storage,
-                                  const Notebook &notebook)
+                                  const ExtendedStorage &storage, const QString &notebookUid)
 {
-    if (storage.isNull() || invitation.isNull() || calendar.isNull())
-        return false;
-
-    return d->executePlugin(SendResponse, invitation, body, calendar, storage, notebook);
+    return d->executePlugin(SendResponse, invitation, body, storage, notebookUid);
 }
 
 QString ServiceHandler::icon(const Notebook &notebook, const ExtendedStorage::Ptr &storage)

--- a/src/servicehandler.cpp
+++ b/src/servicehandler.cpp
@@ -91,7 +91,6 @@ bool ServiceHandlerPrivate::executePlugin(ExecutedPlugin action, const Incidence
         loadPlugins();
 
     Notebook accountNotebook;
-    const QString notebookUid = calendar.notebook(invitation);
     if (storage.isValidNotebook(notebookUid)) {
         accountNotebook = storage.notebook(notebookUid);
     }

--- a/src/servicehandler.cpp
+++ b/src/servicehandler.cpp
@@ -38,7 +38,7 @@ public:
     void loadPlugins();
     bool executePlugin(ExecutedPlugin action, const Incidence::Ptr &invitation, const QString &body,
                        const ExtendedStorage &storage, const QString &notebookUid);
-    ServiceInterface *getServicePlugin(const Notebook &notebook, const ExtendedStorage::Ptr &storage);
+    ServiceInterface *getServicePlugin(const ExtendedStorage::Ptr &storage, const QString &notebookUid);
 
     ServiceHandlerPrivate();
 };
@@ -90,11 +90,10 @@ bool ServiceHandlerPrivate::executePlugin(ExecutedPlugin action, const Incidence
     if (!mLoaded)
         loadPlugins();
 
-    Notebook accountNotebook;
-    if (storage.isValidNotebook(notebookUid)) {
-        accountNotebook = storage.notebook(notebookUid);
-    }
-    if (!accountNotebook.isValid()) {
+    const Notebook accountNotebook = storage.notebook(notebookUid);
+    if (!accountNotebook.isValid() ||
+        accountNotebook.isRunTimeOnly() ||
+        accountNotebook.isReadOnly()) {
         qCWarning(lcMkcal) << "No notebook available for invitation plugin to use";
         return false;
     }
@@ -147,14 +146,18 @@ bool ServiceHandlerPrivate::executePlugin(ExecutedPlugin action, const Incidence
     }
 }
 
-ServiceInterface *ServiceHandlerPrivate::getServicePlugin(const Notebook &notebook,
-                                                          const ExtendedStorage::Ptr &storage)
+ServiceInterface *ServiceHandlerPrivate::getServicePlugin(const ExtendedStorage::Ptr &storage,
+                                                          const QString &notebookUid)
 {
-    if (storage.isNull() || !notebook.isValid())
+    if (storage.isNull())
         return 0;
 
-    if (!storage->isValidNotebook(notebook.uid()))
+    const Notebook &notebook = storage->notebook(notebookUid);
+    if (!notebook.isValid() ||
+        notebook.isRunTimeOnly() ||
+        notebook.isReadOnly()) {
         return 0;
+    }
 
     QString name(notebook.pluginName());
 
@@ -207,7 +210,7 @@ QString ServiceHandler::icon(const Notebook &notebook, const ExtendedStorage::Pt
     if (storage.isNull() || !notebook.isValid())
         return QString();
 
-    ServiceInterface *service = d->getServicePlugin(notebook, storage);
+    ServiceInterface *service = d->getServicePlugin(storage, notebook.uid());
 
     if (service) {
         QString res(service->icon());
@@ -225,7 +228,7 @@ bool ServiceHandler::multiCalendar(const Notebook &notebook, const ExtendedStora
     if (storage.isNull() || !notebook.isValid())
         return false;
 
-    ServiceInterface *service = d->getServicePlugin(notebook, storage);
+    ServiceInterface *service = d->getServicePlugin(storage, notebook.uid());
 
     if (service) {
         bool res = service->multiCalendar();
@@ -243,7 +246,7 @@ QString ServiceHandler::emailAddress(const Notebook &notebook, const ExtendedSto
     if (storage.isNull() || !notebook.isValid())
         return QString();
 
-    ServiceInterface *service = d->getServicePlugin(notebook, storage);
+    ServiceInterface *service = d->getServicePlugin(storage, notebook.uid());
 
     if (service) {
         QString res = service->emailAddress(notebook);
@@ -261,7 +264,7 @@ QString ServiceHandler::displayName(const Notebook &notebook, const ExtendedStor
     if (storage.isNull() || !notebook.isValid())
         return QString();
 
-    ServiceInterface *service = d->getServicePlugin(notebook, storage);
+    ServiceInterface *service = d->getServicePlugin(storage, notebook.uid());
 
     if (service) {
         QString res = service->displayName(notebook);
@@ -280,7 +283,7 @@ int ServiceHandler::downloadAttachment(const Notebook &notebook, const ExtendedS
     if (storage.isNull() || !notebook.isValid())
         return -1;
 
-    ServiceInterface *service = d->getServicePlugin(notebook, storage);
+    ServiceInterface *service = d->getServicePlugin(storage, notebook.uid());
 
     if (service) {
         bool res = service->downloadAttachment(notebook, uri, path);
@@ -299,7 +302,7 @@ bool ServiceHandler::deleteAttachment(const KCalendarCore::Incidence::Ptr &incid
     if (storage.isNull() || !notebook.isValid() || incidence.isNull())
         return false;
 
-    ServiceInterface *service = d->getServicePlugin(notebook, storage);
+    ServiceInterface *service = d->getServicePlugin(storage, notebook.uid());
 
     if (service) {
         bool res = service->deleteAttachment(notebook, incidence, uri);
@@ -320,7 +323,7 @@ bool ServiceHandler::shareNotebook(const Notebook &notebook, const QStringList &
 
     qCDebug(lcMkcal) <<  "shareNotebook";
 
-    ServiceInterface *service = d->getServicePlugin(notebook, storage);
+    ServiceInterface *service = d->getServicePlugin(storage, notebook.uid());
 
     if (service) {
         bool res = service->shareNotebook(notebook, sharedWith);
@@ -338,7 +341,7 @@ QStringList ServiceHandler::sharedWith(const Notebook &notebook, const ExtendedS
     if (storage.isNull() || !notebook.isValid())
         return QStringList();
 
-    ServiceInterface *service = d->getServicePlugin(notebook, storage);
+    ServiceInterface *service = d->getServicePlugin(storage, notebook.uid());
 
     if (service) {
         QStringList res = service->sharedWith(notebook);

--- a/src/servicehandler.h
+++ b/src/servicehandler.h
@@ -85,7 +85,7 @@ public:
       */
     bool sendInvitation(const KCalendarCore::Incidence::Ptr &invitation, const QString &body,
                         const ExtendedCalendar::Ptr &calendar, const ExtendedStorage::Ptr &storage,
-                        const Notebook::Ptr &notebook = Notebook::Ptr());
+                        const Notebook &notebook = Notebook());
 
     /** Send the updated invitation to the list of people stated as attendees.
       It would load the appropriate plugin to do it, and if there
@@ -98,7 +98,7 @@ public:
       @return True if OK, false in case of error
       */
     bool sendUpdate(const KCalendarCore::Incidence::Ptr &invitation, const QString &body, const ExtendedCalendar::Ptr &calendar,
-                    const ExtendedStorage::Ptr &storage, const Notebook::Ptr &notebook = Notebook::Ptr());
+                    const ExtendedStorage::Ptr &storage, const Notebook &notebook = Notebook());
 
     /** Send the updated invitation to the organiser.
       It would load the appropriate plugin to do it, and if there
@@ -112,7 +112,7 @@ public:
       */
     bool sendResponse(const KCalendarCore::Incidence::Ptr &invitation, const QString &body,
                       const ExtendedCalendar::Ptr &calendar, const ExtendedStorage::Ptr &storage,
-                      const Notebook::Ptr &notebook = Notebook::Ptr());
+                      const Notebook &notebook = Notebook());
 
     /** Icon
       It would load the appropriate plugin to do it
@@ -120,7 +120,7 @@ public:
       @param storage Pointer to the storage in use
       @return Icon
       */
-    QString icon(const Notebook::Ptr &notebook, const ExtendedStorage::Ptr &storage);
+    QString icon(const Notebook &notebook, const ExtendedStorage::Ptr &storage);
 
     /** multiCalendar
       It would load the appropriate plugin to do it
@@ -128,7 +128,7 @@ public:
       @param storage Pointer to the storage in use
       @return True if multicalendar otherwise false
       */
-    bool multiCalendar(const Notebook::Ptr &notebook, const ExtendedStorage::Ptr &storage);
+    bool multiCalendar(const Notebook &notebook, const ExtendedStorage::Ptr &storage);
 
     /** emailAddress
       It would load the appropriate plugin to do it
@@ -136,7 +136,7 @@ public:
       @param storage Pointer to the storage in use
       @return email address
       */
-    QString emailAddress(const Notebook::Ptr &notebook, const ExtendedStorage::Ptr &storage);
+    QString emailAddress(const Notebook &notebook, const ExtendedStorage::Ptr &storage);
 
     /** displayName
       It would load the appropriate plugin to do it
@@ -144,7 +144,7 @@ public:
       @param storage Pointer to the storage in use
       @return display name
       */
-    QString displayName(const Notebook::Ptr &notebook, const ExtendedStorage::Ptr &storage);
+    QString displayName(const Notebook &notebook, const ExtendedStorage::Ptr &storage);
 
     /** downloadAttachment
       It would load the appropriate plugin to do it
@@ -155,7 +155,7 @@ public:
       @return Id of the attachment download. It will be used to notify changes about it. If < 0
       there was an error.
       */
-    int downloadAttachment(const Notebook::Ptr &notebook, const ExtendedStorage::Ptr &storage, const QString &uri,
+    int downloadAttachment(const Notebook &notebook, const ExtendedStorage::Ptr &storage, const QString &uri,
                            const QString &path);
 
     /** deleteAttachment
@@ -166,7 +166,7 @@ public:
       @param uri uri of attachment to be deleted
       @return True if OK, false in case of error
       */
-    bool deleteAttachment(const KCalendarCore::Incidence::Ptr &incidence, const Notebook::Ptr &notebook,
+    bool deleteAttachment(const KCalendarCore::Incidence::Ptr &incidence, const Notebook &notebook,
                           const ExtendedStorage::Ptr &storage, const QString &uri);
 
     /** Share notebook
@@ -176,7 +176,7 @@ public:
       @param storage Pointer to the storage in use
       @return True if OK, false in case of error
       */
-    bool shareNotebook(const Notebook::Ptr &notebook, const QStringList &sharedWith, const ExtendedStorage::Ptr &storage);
+    bool shareNotebook(const Notebook &notebook, const QStringList &sharedWith, const ExtendedStorage::Ptr &storage);
 
     /** sharedWith
       It would load the appropriate plugin to do it
@@ -184,7 +184,7 @@ public:
       @param storage Pointer to the storage in use
       @return list of users to share with
       */
-    QStringList sharedWith(const Notebook::Ptr &notebook, const ExtendedStorage::Ptr &storage);
+    QStringList sharedWith(const Notebook &notebook, const ExtendedStorage::Ptr &storage);
 
     /** Try to get the notebook where to put the inviatation.
       This is done based on the product Id of the invitation received. (in the iCal file).

--- a/src/servicehandler.h
+++ b/src/servicehandler.h
@@ -78,41 +78,36 @@ public:
       is no plugin it would use the default fall back plugin.
       @param invitation The Incidence to send
       @param body The body of the reply if any
-      @param calendar Pointer to the calendar in use
-      @param storage Pointer to the storage in use
-      @param notebook Optional notebook to use for account info
+      @param storage The storage in use
+      @param notebookUid uid of the notebook the invitation belongs to
       @return True if OK, false in case of error
       */
     bool sendInvitation(const KCalendarCore::Incidence::Ptr &invitation, const QString &body,
-                        const ExtendedCalendar::Ptr &calendar, const ExtendedStorage::Ptr &storage,
-                        const Notebook &notebook = Notebook());
+                        const ExtendedStorage &storage, const QString &notebookUid);
 
     /** Send the updated invitation to the list of people stated as attendees.
       It would load the appropriate plugin to do it, and if there
       is no plugin it would use the default fall back plugin.
       @param invitation The Incidence to udpate
       @param body The body of the reply if any
-      @param calendar Pointer to the calendar in use
-      @param storage Pointer to the storage in use
-      @param notebook Optional notebook to use for account info
+      @param storage The storage in use
+      @param notebookUid uid of the notebook the invitation belongs to
       @return True if OK, false in case of error
       */
-    bool sendUpdate(const KCalendarCore::Incidence::Ptr &invitation, const QString &body, const ExtendedCalendar::Ptr &calendar,
-                    const ExtendedStorage::Ptr &storage, const Notebook &notebook = Notebook());
+    bool sendUpdate(const KCalendarCore::Incidence::Ptr &invitation, const QString &body,
+                    const ExtendedStorage &storage, const QString &notebookUid);
 
     /** Send the updated invitation to the organiser.
       It would load the appropriate plugin to do it, and if there
       is no plugin it would use the default fall back plugin.
       @param invitation The Incidence to udpate
       @param body The body of the reply if any
-      @param calendar Pointer to the calendar in use
-      @param storage Pointer to the storage in use
-      @param notebook Optional notebook to use for account info
+      @param storage The storage in use
+      @param notebookUid uid of the notebook the invitation belongs to
       @return True if OK, false in case of error
       */
     bool sendResponse(const KCalendarCore::Incidence::Ptr &invitation, const QString &body,
-                      const ExtendedCalendar::Ptr &calendar, const ExtendedStorage::Ptr &storage,
-                      const Notebook &notebook = Notebook());
+                      const ExtendedStorage &storage, const QString &notebookUid);
 
     /** Icon
       It would load the appropriate plugin to do it

--- a/src/servicehandlerif.h
+++ b/src/servicehandlerif.h
@@ -86,13 +86,13 @@ public:
         @param notebook pointer to the notebook that we want to share
         @return email address of service
     */
-    virtual QString emailAddress(const mKCal::Notebook::Ptr &notebook) = 0;
+    virtual QString emailAddress(const mKCal::Notebook &notebook) = 0;
 
     /** \brief returns the display name of account of service.
         @param notebook pointer to the notebook that we want to share
         @return display name of account of service
     */
-    virtual QString displayName(const mKCal::Notebook::Ptr &notebook) const = 0;
+    virtual QString displayName(const mKCal::Notebook &notebook) const = 0;
 
     /** \brief Start the download of an attachment.
         This cannot be a blocking operation.
@@ -112,7 +112,7 @@ public:
         @param path path where attachment to be downloaded to
     @return True if OK, false otherwise.
     */
-    virtual bool downloadAttachment(const mKCal::Notebook::Ptr &notebook, const QString &uri, const QString &path) = 0;
+    virtual bool downloadAttachment(const mKCal::Notebook &notebook, const QString &uri, const QString &path) = 0;
 
     /** \brief start the deletion of an attachment.
         @param notebook pointer to the notebook
@@ -120,7 +120,7 @@ public:
         @param uri uri of attachment to be deleted
     @return True if OK, false otherwise.
     */
-    virtual bool deleteAttachment(const mKCal::Notebook::Ptr &notebook, const KCalendarCore::Incidence::Ptr &incidence,
+    virtual bool deleteAttachment(const mKCal::Notebook &notebook, const KCalendarCore::Incidence::Ptr &incidence,
                                   const QString &uri) = 0;
 
     /** \brief Share notebook.
@@ -128,13 +128,13 @@ public:
         @param sharedWith email address or phone number of users
         @return True if OK, false otherwise.
     */
-    virtual bool shareNotebook(const mKCal::Notebook::Ptr &notebook, const QStringList &sharedWith) = 0;
+    virtual bool shareNotebook(const mKCal::Notebook &notebook, const QStringList &sharedWith) = 0;
 
     /** \brief Returns list of emails, phones# of the persons that a notebook is shared with.
         @param notebook pointer to the notebook
         @return list of email addresses or phone numbers
     */
-    virtual QStringList sharedWith(const mKCal::Notebook::Ptr &notebook) = 0;
+    virtual QStringList sharedWith(const mKCal::Notebook &notebook) = 0;
 
     /** \brief The name of this service.
         It should be a uniq name specifying which service to use

--- a/src/sqliteformat.cpp
+++ b/src/sqliteformat.cpp
@@ -56,6 +56,9 @@ public:
     {
         sqlite3_finalize(mSelectMetadata);
         sqlite3_finalize(mUpdateMetadata);
+        sqlite3_finalize(mInsertCalendar);
+        sqlite3_finalize(mUpdateCalendar);
+        sqlite3_finalize(mDeleteCalendar);
         sqlite3_finalize(mSelectCalProps);
         sqlite3_finalize(mInsertCalProps);
         sqlite3_finalize(mSelectIncProperties);
@@ -90,6 +93,9 @@ public:
     sqlite3_stmt *mSelectMetadata = nullptr;
     sqlite3_stmt *mUpdateMetadata = nullptr;
 
+    sqlite3_stmt *mInsertCalendar = nullptr;
+    sqlite3_stmt *mUpdateCalendar = nullptr;
+    sqlite3_stmt *mDeleteCalendar = nullptr;
     sqlite3_stmt *mSelectCalProps = nullptr;
     sqlite3_stmt *mInsertCalProps = nullptr;
 
@@ -123,27 +129,27 @@ public:
     sqlite3_stmt *mMarkDeletedIncidences = nullptr;
 
     bool updateMetadata(int transactionId);
-    bool selectCustomproperties(Incidence::Ptr &incidence, int rowid);
-    int selectRowId(Incidence::Ptr incidence);
-    bool selectRecursives(Incidence::Ptr &incidence, int rowid);
-    bool selectAlarms(Incidence::Ptr &incidence, int rowid);
-    bool selectAttendees(Incidence::Ptr &incidence, int rowid);
-    bool selectRdates(Incidence::Ptr &incidence, int rowid);
-    bool selectAttachments(Incidence::Ptr &incidence, int rowid);
-    bool selectCalendarProperties(Notebook::Ptr notebook);
-    bool insertCustomproperties(Incidence::Ptr incidence, int rowid);
+    bool selectCustomproperties(Incidence *incidence, int rowid);
+    int selectRowId(const Incidence &incidence);
+    bool selectRecursives(Incidence *incidence, int rowid);
+    bool selectAlarms(Incidence *incidence, int rowid);
+    bool selectAttendees(Incidence *incidence, int rowid);
+    bool selectRdates(Incidence *incidence, int rowid);
+    bool selectAttachments(Incidence *incidence, int rowid);
+    bool selectCalendarProperties(Notebook *notebook);
+    bool insertCustomproperties(const Incidence &incidence, int rowid);
     bool insertCustomproperty(int rowid, const QByteArray &key, const QString &value, const QString &parameters);
-    bool insertAttendees(Incidence::Ptr incidence, int rowid);
+    bool insertAttendees(const Incidence &incidence, int rowid);
     bool insertAttendee(int rowid, const Attendee &attendee, bool isOrganizer);
-    bool insertAttachments(Incidence::Ptr incidence, int rowid);
-    bool insertAlarms(Incidence::Ptr incidence, int rowid);
+    bool insertAttachments(const Incidence &incidence, int rowid);
+    bool insertAlarms(const Incidence &incidence, int rowid);
     bool insertAlarm(int rowid, Alarm::Ptr alarm);
-    bool insertRecursives(Incidence::Ptr incidence, int rowid);
+    bool insertRecursives(const Incidence &incidence, int rowid);
     bool insertRecursive(int rowid, RecurrenceRule *rule, int type);
-    bool insertRdates(Incidence::Ptr incidence, int rowid);
+    bool insertRdates(const Incidence &incidence, int rowid);
     bool insertRdate(int rowid, int type, const QDateTime &rdate, bool allDay);
     bool deleteListsForIncidence(int rowid);
-    bool modifyCalendarProperties(Notebook::Ptr notebook, DBOperation dbop);
+    bool modifyCalendarProperties(const Notebook &notebook, DBOperation dbop);
     bool deleteCalendarProperties(const QByteArray &id);
     bool insertCalendarProperty(const QByteArray &id, const QByteArray &key,
                                 const QByteArray &value);
@@ -220,25 +226,61 @@ error:
     return false;
 }
 
-bool SqliteFormat::modifyCalendars(const Notebook::Ptr &notebook,
-                                   DBOperation dbop, sqlite3_stmt *stmt, bool isDefault)
+bool SqliteFormat::modifyCalendars(const Notebook &notebook,
+                                   DBOperation dbop, bool isDefault)
 {
     int rv = 0;
     int index = 1;
-    QByteArray uid = notebook->uid().toUtf8();
-    QByteArray name = notebook->name().toUtf8();
-    QByteArray description = notebook->description().toUtf8();
-    QByteArray color = notebook->color().toUtf8();
-    QByteArray plugin = notebook->pluginName().toUtf8();
-    QByteArray account = notebook->account().toUtf8();
-    QByteArray sharedWith = notebook->sharedWithStr().toUtf8();
-    QByteArray syncProfile = notebook->syncProfile().toUtf8();
+    sqlite3_stmt *stmt;
+    QByteArray uid = notebook.uid().toUtf8();
+    QByteArray name = notebook.name().toUtf8();
+    QByteArray description = notebook.description().toUtf8();
+    QByteArray color = notebook.color().toUtf8();
+    QByteArray plugin = notebook.pluginName().toUtf8();
+    QByteArray account = notebook.account().toUtf8();
+    QByteArray sharedWith = notebook.sharedWithStr().toUtf8();
+    QByteArray syncProfile = notebook.syncProfile().toUtf8();
 
     sqlite3_int64  secs;
+    const char *operation = (dbop == DBInsert) ? "inserting" :
+                            (dbop == DBUpdate) ? "updating" : "deleting";
 
-    index = 1;
-    if (dbop == DBInsert || dbop == DBDelete)
-        SL3_bind_text(stmt, index, uid, uid.length(), SQLITE_STATIC);
+    switch (dbop) {
+    case DBDelete:
+        if (!d->mDeleteCalendar) {
+            const char *query = DELETE_CALENDARS;
+            int qsize = sizeof(DELETE_CALENDARS);
+            SL3_prepare_v2(d->mDatabase, query, qsize, &d->mDeleteCalendar, nullptr);
+        }
+        SL3_reset(d->mDeleteCalendar);
+        SL3_bind_text(d->mDeleteCalendar, index, uid, uid.length(), SQLITE_STATIC);
+        stmt = d->mDeleteCalendar;
+        break;
+    case DBInsert:
+        if (!d->mInsertCalendar) {
+            const char *query = INSERT_CALENDARS;
+            int qsize = sizeof(INSERT_CALENDARS);
+            SL3_prepare_v2(d->mDatabase, query, qsize, &d->mInsertCalendar, nullptr);
+        }
+        SL3_reset(d->mInsertCalendar);
+        SL3_bind_text(d->mInsertCalendar, index, uid, uid.length(), SQLITE_STATIC);
+        stmt = d->mInsertCalendar;
+        break;
+    case DBUpdate:
+        if (!d->mUpdateCalendar) {
+            const char *query = UPDATE_CALENDARS;
+            int qsize = sizeof(UPDATE_CALENDARS);
+            SL3_prepare_v2(d->mDatabase, query, qsize, &d->mUpdateCalendar, nullptr);
+        }
+        SL3_reset(d->mUpdateCalendar);
+        stmt = d->mUpdateCalendar;
+        break;
+    default:
+        qCWarning(lcMkcal) << "unknown notebook DB operation" << dbop;
+        return false;
+    }
+
+    qCDebug(lcMkcal) << operation << "notebook" << uid << name << "in database";
 
     if (dbop == DBInsert || dbop == DBUpdate) {
         int flags = 0;
@@ -253,30 +295,32 @@ bool SqliteFormat::modifyCalendars(const Notebook::Ptr &notebook,
             sqlite3_finalize(unset);
             flags |= SqliteFormat::Default;
         }
-        flags |= notebook->eventsAllowed() ? SqliteFormat::AllowEvents : 0;
-        flags |= notebook->todosAllowed() ? SqliteFormat::AllowTodos : 0;
-        flags |= notebook->journalsAllowed() ? SqliteFormat::AllowJournals : 0;
-        flags |= notebook->isShared() ? SqliteFormat::Shared : 0;
-        flags |= notebook->isMaster() ? SqliteFormat::Master : 0;
-        flags |= notebook->isSynchronized() ? SqliteFormat::Synchronized : 0;
-        flags |= notebook->isReadOnly() ? SqliteFormat::ReadOnly : 0;
-        flags |= notebook->isVisible() ? SqliteFormat::Visible : 0;
-        flags |= notebook->isRunTimeOnly() ? SqliteFormat::RunTimeOnly : 0;
-        flags |= notebook->isShareable() ? SqliteFormat::Shareable : 0;
+        flags |= notebook.eventsAllowed() ? SqliteFormat::AllowEvents : 0;
+        flags |= notebook.todosAllowed() ? SqliteFormat::AllowTodos : 0;
+        flags |= notebook.journalsAllowed() ? SqliteFormat::AllowJournals : 0;
+        flags |= notebook.isShared() ? SqliteFormat::Shared : 0;
+        flags |= notebook.isMaster() ? SqliteFormat::Master : 0;
+        flags |= notebook.isSynchronized() ? SqliteFormat::Synchronized : 0;
+        flags |= notebook.isReadOnly() ? SqliteFormat::ReadOnly : 0;
+        flags |= notebook.isVisible() ? SqliteFormat::Visible : 0;
+        flags |= notebook.isRunTimeOnly() ? SqliteFormat::RunTimeOnly : 0;
+        flags |= notebook.isShareable() ? SqliteFormat::Shareable : 0;
         SL3_bind_text(stmt, index, name, name.length(), SQLITE_STATIC);
         SL3_bind_text(stmt, index, description, description.length(), SQLITE_STATIC);
         SL3_bind_text(stmt, index, color, color.length(), SQLITE_STATIC);
         SL3_bind_int(stmt, index, flags);
-        secs = toOriginTime(notebook->syncDate().toUTC());
+        secs = toOriginTime(notebook.syncDate().toUTC());
         SL3_bind_int64(stmt, index, secs);
         SL3_bind_text(stmt, index, plugin, plugin.length(), SQLITE_STATIC);
         SL3_bind_text(stmt, index, account, account.length(), SQLITE_STATIC);
-        SL3_bind_int64(stmt, index, notebook->attachmentSize());
-        secs = toOriginTime(notebook->modifiedDate().toUTC());
+        SL3_bind_int64(stmt, index, notebook.attachmentSize());
+        secs = toOriginTime(notebook.modifiedDate().toUTC());
         SL3_bind_int64(stmt, index, secs);
         SL3_bind_text(stmt, index, sharedWith, sharedWith.length(), SQLITE_STATIC);
         SL3_bind_text(stmt, index, syncProfile, syncProfile.length(), SQLITE_STATIC);
-        secs = toOriginTime(notebook->creationDate().toUTC());
+        secs = toOriginTime(notebook.creationDate().isValid()
+                            ? notebook.creationDate().toUTC()
+                            : QDateTime::currentDateTimeUtc());
         SL3_bind_int64(stmt, index, secs);
 
         if (dbop == DBUpdate)
@@ -296,17 +340,17 @@ error:
     return false;
 }
 
-bool SqliteFormat::purgeDeletedComponents(const KCalendarCore::Incidence::Ptr &incidence)
+bool SqliteFormat::purgeDeletedComponents(const KCalendarCore::Incidence &incidence)
 {
     int rv;
     int index = 1;
-    const QByteArray u(incidence->uid().toUtf8());
+    const QByteArray u(incidence.uid().toUtf8());
     qint64 secsRecurId = 0;
 
-    if (incidence->hasRecurrenceId() && incidence->recurrenceId().timeSpec() == Qt::LocalTime) {
-        secsRecurId = toLocalOriginTime(incidence->recurrenceId());
-    } else if (incidence->hasRecurrenceId()) {
-        secsRecurId = toOriginTime(incidence->recurrenceId());
+    if (incidence.hasRecurrenceId() && incidence.recurrenceId().timeSpec() == Qt::LocalTime) {
+        secsRecurId = toLocalOriginTime(incidence.recurrenceId());
+    } else if (incidence.hasRecurrenceId()) {
+        secsRecurId = toOriginTime(incidence.recurrenceId());
     }
 
     if (!d->mDeleteIncComponents) {
@@ -381,7 +425,7 @@ static bool setDateTime(SqliteFormat *format, sqlite3_stmt *stmt, int &index, co
             goto error;                                                \
     }
 
-bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QString &nbook,
+bool SqliteFormat::modifyComponents(const Incidence &incidence, const QString &nbook,
                                     DBOperation dbop)
 {
     int rv = 0;
@@ -410,7 +454,7 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
             // Already deleted.
             return true;
         } else if (!rowid) {
-            qCWarning(lcMkcal) << "failed to select rowid of incidence" << incidence->uid() << incidence->recurrenceId();
+            qCWarning(lcMkcal) << "failed to select rowid of incidence" << incidence.uid() << incidence.recurrenceId();
             goto error;
         }
     }
@@ -465,7 +509,7 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
         notebook = nbook.toUtf8();
         SL3_bind_text(stmt1, index, notebook.constData(), notebook.length(), SQLITE_STATIC);
 
-        switch (incidence->type()) {
+        switch (incidence.type()) {
         case Incidence::TypeEvent:
             type = "Event";
             break;
@@ -483,75 +527,75 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
         }
         SL3_bind_text(stmt1, index, type.constData(), type.length(), SQLITE_STATIC);   // NOTE
 
-        summary = incidence->summary().toUtf8();
+        summary = incidence.summary().toUtf8();
         SL3_bind_text(stmt1, index, summary.constData(), summary.length(), SQLITE_STATIC);
 
-        category = incidence->categoriesStr().toUtf8();
+        category = incidence.categoriesStr().toUtf8();
         SL3_bind_text(stmt1, index, category.constData(), category.length(), SQLITE_STATIC);
 
-        if ((incidence->type() == Incidence::TypeEvent) ||
-                (incidence->type() == Incidence::TypeJournal)) {
-            SL3_bind_date_time(this, stmt1, index, incidence->dtStart(), incidence->allDay());
+        if ((incidence.type() == Incidence::TypeEvent) ||
+                (incidence.type() == Incidence::TypeJournal)) {
+            SL3_bind_date_time(this, stmt1, index, incidence.dtStart(), incidence.allDay());
 
             // set HasDueDate to false
             SL3_bind_int(stmt1, index, 0);
 
             QDateTime effectiveDtEnd;
-            if (incidence->type() == Incidence::TypeEvent) {
-                Event::Ptr event = incidence.staticCast<Event>();
-                if (event->hasEndDate()) {
+            if (incidence.type() == Incidence::TypeEvent) {
+                const Event &event = static_cast<const Event&>(incidence);
+                if (event.hasEndDate()) {
                     // Keep this one day addition for backward compatibility reasons
                     // with existing events in database.
-                    if (incidence->allDay()) {
-                        effectiveDtEnd = event->dtEnd().addDays(1);
+                    if (incidence.allDay()) {
+                        effectiveDtEnd = event.dtEnd().addDays(1);
                     } else {
-                        effectiveDtEnd = event->dtEnd();
+                        effectiveDtEnd = event.dtEnd();
                     }
                 }
             }
-            SL3_bind_date_time(this, stmt1, index, effectiveDtEnd, incidence->allDay());
-        } else if (incidence->type() == Incidence::TypeTodo) {
-            Todo::Ptr todo = incidence.staticCast<Todo>();
+            SL3_bind_date_time(this, stmt1, index, effectiveDtEnd, incidence.allDay());
+        } else if (incidence.type() == Incidence::TypeTodo) {
+            const Todo &todo = static_cast<const Todo&>(incidence);
             SL3_bind_date_time(this, stmt1, index,
-                               todo->hasStartDate() ? todo->dtStart(true) : QDateTime(), todo->allDay());
+                               todo.hasStartDate() ? todo.dtStart(true) : QDateTime(), todo.allDay());
 
-            SL3_bind_int(stmt1, index, (int) todo->hasDueDate());
+            SL3_bind_int(stmt1, index, (int) todo.hasDueDate());
 
-            SL3_bind_date_time(this, stmt1, index, todo->hasDueDate() ? todo->dtDue(true) : QDateTime(), todo->allDay());
+            SL3_bind_date_time(this, stmt1, index, todo.hasDueDate() ? todo.dtDue(true) : QDateTime(), todo.allDay());
         }
 
-        if (incidence->type() != Incidence::TypeJournal) {
-            SL3_bind_int(stmt1, index, incidence->duration().asSeconds()); // NOTE
+        if (incidence.type() != Incidence::TypeJournal) {
+            SL3_bind_int(stmt1, index, incidence.duration().asSeconds()); // NOTE
         } else {
             SL3_bind_int(stmt1, index, 0);
         }
 
-        SL3_bind_int(stmt1, index, incidence->secrecy()); // NOTE
+        SL3_bind_int(stmt1, index, incidence.secrecy()); // NOTE
 
-        if (incidence->type() != Incidence::TypeJournal) {
-            location = incidence->location().toUtf8();
+        if (incidence.type() != Incidence::TypeJournal) {
+            location = incidence.location().toUtf8();
             SL3_bind_text(stmt1, index, location.constData(), location.length(), SQLITE_STATIC);
         } else {
             SL3_bind_text(stmt1, index, "", 0, SQLITE_STATIC);
         }
 
-        description = incidence->description().toUtf8();
+        description = incidence.description().toUtf8();
         SL3_bind_text(stmt1, index, description.constData(), description.length(), SQLITE_STATIC);
 
-        SL3_bind_int(stmt1, index, incidence->status()); // NOTE
+        SL3_bind_int(stmt1, index, incidence.status()); // NOTE
 
-        if (incidence->type() != Incidence::TypeJournal) {
-            if (incidence->hasGeo()) {
-                SL3_bind_double(stmt1, index, incidence->geoLatitude());
-                SL3_bind_double(stmt1, index, incidence->geoLongitude());
+        if (incidence.type() != Incidence::TypeJournal) {
+            if (incidence.hasGeo()) {
+                SL3_bind_double(stmt1, index, incidence.geoLatitude());
+                SL3_bind_double(stmt1, index, incidence.geoLongitude());
             } else {
                 SL3_bind_double(stmt1, index, INVALID_LATLON);
                 SL3_bind_double(stmt1, index, INVALID_LATLON);
             }
 
-            SL3_bind_int(stmt1, index, incidence->priority());
+            SL3_bind_int(stmt1, index, incidence.priority());
 
-            resources = incidence->resources().join(" ").toUtf8();
+            resources = incidence.resources().join(" ").toUtf8();
             SL3_bind_text(stmt1, index, resources.constData(), resources.length(), SQLITE_STATIC);
         } else {
             SL3_bind_double(stmt1, index, INVALID_LATLON);
@@ -560,69 +604,66 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
             SL3_bind_text(stmt1, index, "", 0, SQLITE_STATIC);
         }
 
-        if (dbop == DBInsert && incidence->created().isNull())
-            incidence->setCreated(QDateTime::currentDateTimeUtc());
-        secs = toOriginTime(incidence->created());
+        secs = toOriginTime(incidence.created());
         SL3_bind_int64(stmt1, index, secs);
 
         secs = toOriginTime(QDateTime::currentDateTimeUtc());
         SL3_bind_int64(stmt1, index, secs);   // datestamp
 
-        secs = toOriginTime(incidence->lastModified());
+        secs = toOriginTime(incidence.lastModified());
         SL3_bind_int64(stmt1, index, secs);
 
-        SL3_bind_int(stmt1, index, incidence->revision());
+        SL3_bind_int(stmt1, index, incidence.revision());
 
-        comments = incidence->comments().join(" ").toUtf8();
+        comments = incidence.comments().join(" ").toUtf8();
         SL3_bind_text(stmt1, index, comments.constData(), comments.length(), SQLITE_STATIC);
 
         // Attachments are now stored in a dedicated table.
         SL3_bind_text(stmt1, index, nullptr, 0, SQLITE_STATIC);
 
-        contact = incidence->contacts().join(" ").toUtf8();
+        contact = incidence.contacts().join(" ").toUtf8();
         SL3_bind_text(stmt1, index, contact.constData(), contact.length(), SQLITE_STATIC);
 
         // Never save recurrenceId as FLOATING_DATE, because the time of a
         // floating date is not guaranteed on read and recurrenceId is used
         // for date-time comparisons.
-        SL3_bind_date_time(this, stmt1, index, incidence->recurrenceId(), false);
+        SL3_bind_date_time(this, stmt1, index, incidence.recurrenceId(), false);
 
-        relatedtouid = incidence->relatedTo().toUtf8();
+        relatedtouid = incidence.relatedTo().toUtf8();
         SL3_bind_text(stmt1, index, relatedtouid.constData(), relatedtouid.length(), SQLITE_STATIC);
 
-        url = incidence->url().toString().toUtf8();
+        url = incidence.url().toString().toUtf8();
         SL3_bind_text(stmt1, index, url.constData(), url.length(), SQLITE_STATIC);
 
-        uid = incidence->uid().toUtf8();
+        uid = incidence.uid().toUtf8();
         SL3_bind_text(stmt1, index, uid.constData(), uid.length(), SQLITE_STATIC);
 
-        if (incidence->type() == Incidence::TypeEvent) {
-            Event::Ptr event = incidence.staticCast<Event>();
-            SL3_bind_int(stmt1, index, (int)event->transparency());
+        if (incidence.type() == Incidence::TypeEvent) {
+            const Event &event = static_cast<const Event&>(incidence);
+            SL3_bind_int(stmt1, index, (int)event.transparency());
         } else {
             SL3_bind_int(stmt1, index, 0);
         }
 
-        SL3_bind_int(stmt1, index, (int) incidence->localOnly());
+        SL3_bind_int(stmt1, index, (int) incidence.localOnly());
 
         int percentComplete = 0;
         QDateTime effectiveDtCompleted;
-        if (incidence->type() == Incidence::TypeTodo) {
-            Todo::Ptr todo = incidence.staticCast<Todo>();
-            percentComplete = todo->percentComplete();
-            if (todo->isCompleted()) {
-                if (!todo->hasCompletedDate()) {
-                    // If the todo was created by KOrganizer<2.2 it does not have
-                    // a correct completion date. Set one now.
-                    todo->setCompleted(QDateTime::currentDateTimeUtc());
+        if (incidence.type() == Incidence::TypeTodo) {
+            const Todo &todo = static_cast<const Todo&>(incidence);
+            percentComplete = todo.percentComplete();
+            if (todo.isCompleted()) {
+                if (!todo.hasCompletedDate()) {
+                    effectiveDtCompleted = QDateTime::currentDateTimeUtc();
+                } else {
+                    effectiveDtCompleted = todo.completed();
                 }
-                effectiveDtCompleted = todo->completed();
             }
         }
         SL3_bind_int(stmt1, index, percentComplete);
-        SL3_bind_date_time(this, stmt1, index, effectiveDtCompleted, incidence->allDay());
+        SL3_bind_date_time(this, stmt1, index, effectiveDtCompleted, incidence.allDay());
 
-        colorstr = incidence->color().toUtf8();
+        colorstr = incidence.color().toUtf8();
         SL3_bind_text(stmt1, index, colorstr.constData(), colorstr.length(), SQLITE_STATIC);
 
         if (dbop == DBUpdate)
@@ -632,28 +673,28 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
     SL3_step(stmt1);
 
     if ((dbop == DBDelete || dbop == DBUpdate) && !d->deleteListsForIncidence(rowid)) {
-        qCWarning(lcMkcal) << "failed to delete lists for incidence" << incidence->uid();
+        qCWarning(lcMkcal) << "failed to delete lists for incidence" << incidence.uid();
     } else if (dbop == DBInsert || dbop == DBUpdate) {
         if (dbop == DBInsert)
             rowid = sqlite3_last_insert_rowid(d->mDatabase);
 
         if (!d->insertCustomproperties(incidence, rowid))
-            qCWarning(lcMkcal) << "failed to modify customproperties for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify customproperties for incidence" << incidence.uid();
 
         if (!d->insertAttendees(incidence, rowid))
-            qCWarning(lcMkcal) << "failed to modify attendees for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify attendees for incidence" << incidence.uid();
 
         if (!d->insertAlarms(incidence, rowid))
-            qCWarning(lcMkcal) << "failed to modify alarms for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify alarms for incidence" << incidence.uid();
 
         if (!d->insertRecursives(incidence, rowid))
-            qCWarning(lcMkcal) << "failed to modify recursives for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify recursives for incidence" << incidence.uid();
 
         if (!d->insertRdates(incidence, rowid))
-            qCWarning(lcMkcal) << "failed to modify rdates for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify rdates for incidence" << incidence.uid();
 
         if (!d->insertAttachments(incidence, rowid))
-            qCWarning(lcMkcal) << "failed to modify attachments for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify attachments for incidence" << incidence.uid();
     }
 
     return true;
@@ -735,15 +776,15 @@ error:
     return false;
 }
 
-bool SqliteFormat::Private::insertCustomproperties(Incidence::Ptr incidence, int rowid)
+bool SqliteFormat::Private::insertCustomproperties(const Incidence &incidence, int rowid)
 {
     bool success = true;
 
-    QMap<QByteArray, QString> mProperties = incidence->customProperties();
+    QMap<QByteArray, QString> mProperties = incidence.customProperties();
     for (QMap<QByteArray, QString>::ConstIterator it = mProperties.begin(); it != mProperties.end(); ++it) {
         if (!insertCustomproperty(rowid, it.key(), it.value(),
-                                  incidence->nonKDECustomPropertyParameters(it.key()))) {
-            qCWarning(lcMkcal) << "failed to modify customproperty for incidence" << incidence->uid();
+                                  incidence.nonKDECustomPropertyParameters(it.key()))) {
+            qCWarning(lcMkcal) << "failed to modify customproperty for incidence" << incidence.uid();
             success = false;
         }
     }
@@ -780,25 +821,25 @@ error:
     return false;
 }
 
-bool SqliteFormat::Private::insertRdates(Incidence::Ptr incidence, int rowid)
+bool SqliteFormat::Private::insertRdates(const Incidence &incidence, int rowid)
 {
     bool success = true;
 
     int type = SqliteFormat::RDate;
-    DateList dateList = incidence->recurrence()->rDates();
+    DateList dateList = incidence.recurrence()->rDates();
     DateList::ConstIterator dt;
     for (dt = dateList.constBegin(); dt != dateList.constEnd(); ++dt) {
         if (!insertRdate(rowid, type, QDateTime((*dt)), true)) {
-            qCWarning(lcMkcal) << "failed to modify rdates for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify rdates for incidence" << incidence.uid();
             success = false;
         }
     }
 
     type = SqliteFormat::XDate;
-    dateList = incidence->recurrence()->exDates();
+    dateList = incidence.recurrence()->exDates();
     for (dt = dateList.constBegin(); dt != dateList.constEnd(); ++dt) {
         if (!insertRdate(rowid, type, QDateTime((*dt)), true)) {
-            qCWarning(lcMkcal) << "failed to modify xdates for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify xdates for incidence" << incidence.uid();
             success = false;
         }
     }
@@ -811,22 +852,22 @@ bool SqliteFormat::Private::insertRdates(Incidence::Ptr incidence, int rowid)
     // When saving, we don't want to store this local zone info, otherwise,
     // the saved date-time won't match when read in another time zone.
     type = SqliteFormat::RDateTime;
-    DateTimeList dateTimeList = incidence->recurrence()->rDateTimes();
+    DateTimeList dateTimeList = incidence.recurrence()->rDateTimes();
     DateTimeList::ConstIterator it;
     for (it = dateTimeList.constBegin(); it != dateTimeList.constEnd(); ++it) {
-        bool allDay(incidence->allDay() && it->timeSpec() == Qt::LocalTime && it->time() == QTime(0,0));
+        bool allDay(incidence.allDay() && it->timeSpec() == Qt::LocalTime && it->time() == QTime(0,0));
         if (!insertRdate(rowid, type, *it, allDay)) {
-            qCWarning(lcMkcal) << "failed to modify rdatetimes for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify rdatetimes for incidence" << incidence.uid();
             success = false;
         }
     }
 
     type = SqliteFormat::XDateTime;
-    dateTimeList = incidence->recurrence()->exDateTimes();
+    dateTimeList = incidence.recurrence()->exDateTimes();
     for (it = dateTimeList.constBegin(); it != dateTimeList.constEnd(); ++it) {
-        bool allDay(incidence->allDay() && it->timeSpec() == Qt::LocalTime && it->time() == QTime(0,0));
+        bool allDay(incidence.allDay() && it->timeSpec() == Qt::LocalTime && it->time() == QTime(0,0));
         if (!insertRdate(rowid, type, *it, allDay)) {
-            qCWarning(lcMkcal) << "failed to modify xdatetimes for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify xdatetimes for incidence" << incidence.uid();
             success = false;
         }
     }
@@ -857,15 +898,15 @@ error:
     return false;
 }
 
-bool SqliteFormat::Private::insertAlarms(Incidence::Ptr incidence, int rowid)
+bool SqliteFormat::Private::insertAlarms(const Incidence &incidence, int rowid)
 {
     bool success = true;
 
-    const Alarm::List &list = incidence->alarms();
+    const Alarm::List &list = incidence.alarms();
     Alarm::List::ConstIterator it;
     for (it = list.begin(); it != list.end(); ++it) {
         if (!insertAlarm(rowid, *it)) {
-            qCWarning(lcMkcal) << "failed to modify alarm for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify alarm for incidence" << incidence.uid();
             success = false;
         }
     }
@@ -983,22 +1024,22 @@ error:
     return false;
 }
 
-bool SqliteFormat::Private::insertRecursives(Incidence::Ptr incidence, int rowid)
+bool SqliteFormat::Private::insertRecursives(const Incidence &incidence, int rowid)
 {
     bool success = true;
 
-    const RecurrenceRule::List &listRR = incidence->recurrence()->rRules();
+    const RecurrenceRule::List &listRR = incidence.recurrence()->rRules();
     RecurrenceRule::List::ConstIterator it;
     for (it = listRR.begin(); it != listRR.end(); ++it) {
         if (!insertRecursive(rowid, *it, 1)) {
-            qCWarning(lcMkcal) << "failed to modify recursive for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify recursive for incidence" << incidence.uid();
             success = false;
         }
     }
-    const RecurrenceRule::List &listER = incidence->recurrence()->exRules();
+    const RecurrenceRule::List &listER = incidence.recurrence()->exRules();
     for (it = listER.begin(); it != listER.end(); ++it) {
         if (!insertRecursive(rowid, *it, 2)) {
-            qCWarning(lcMkcal) << "failed to modify recursive for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify recursive for incidence" << incidence.uid();
             success = false;
         }
     }
@@ -1103,7 +1144,7 @@ error:
     return false;
 }
 
-bool SqliteFormat::Private::insertAttendees(Incidence::Ptr incidence, int rowid)
+bool SqliteFormat::Private::insertAttendees(const Incidence &incidence, int rowid)
 {
     bool success = true;
 
@@ -1111,17 +1152,17 @@ bool SqliteFormat::Private::insertAttendees(Incidence::Ptr incidence, int rowid)
     // e.g. has constraints that every attendee must have email and they need to be unique among the attendees.
     // also this forces attendee list to include the organizer.
     QString organizerEmail;
-    if (!incidence->organizer().isEmpty()) {
-        organizerEmail = incidence->organizer().email();
-        Attendee organizer = incidence->attendeeByMail(organizerEmail);
+    if (!incidence.organizer().isEmpty()) {
+        organizerEmail = incidence.organizer().email();
+        Attendee organizer = incidence.attendeeByMail(organizerEmail);
         if (organizer.isNull())
-            organizer = Attendee(incidence->organizer().name(), organizerEmail);
+            organizer = Attendee(incidence.organizer().name(), organizerEmail);
         if (!insertAttendee(rowid, organizer, true)) {
-            qCWarning(lcMkcal) << "failed to modify organizer for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify organizer for incidence" << incidence.uid();
             success = false;
         }
     }
-    const Attendee::List &list = incidence->attendees();
+    const Attendee::List &list = incidence.attendees();
     Attendee::List::ConstIterator it;
     for (it = list.begin(); it != list.end(); ++it) {
         if (it->email().isEmpty()) {
@@ -1131,7 +1172,7 @@ bool SqliteFormat::Private::insertAttendees(Incidence::Ptr incidence, int rowid)
             continue; // already added above
         }
         if (!insertAttendee(rowid, *it, false)) {
-            qCWarning(lcMkcal) << "failed to modify attendee for incidence" << incidence->uid();
+            qCWarning(lcMkcal) << "failed to modify attendee for incidence" << incidence.uid();
             success = false;
         }
     }
@@ -1184,9 +1225,9 @@ error:
     return false;
 }
 
-bool SqliteFormat::Private::insertAttachments(Incidence::Ptr incidence, int rowid)
+bool SqliteFormat::Private::insertAttachments(const Incidence &incidence, int rowid)
 {
-    const Attachment::List &list = incidence->attachments();
+    const Attachment::List &list = incidence.attachments();
     Attachment::List::ConstIterator it;
     for (it = list.begin(); it != list.end(); ++it) {
         int rv = 0;
@@ -1222,14 +1263,15 @@ bool SqliteFormat::Private::insertAttachments(Incidence::Ptr incidence, int rowi
     return true;
 
 error:
-    qCWarning(lcMkcal) << "cannot modify attachment for incidence" << incidence->instanceIdentifier();
+    qCWarning(lcMkcal) << "cannot modify attachment for incidence" << incidence.instanceIdentifier();
     qCWarning(lcMkcal) << "Sqlite error:" << sqlite3_errmsg(mDatabase);
     return false;
 }
 
-bool SqliteFormat::Private::modifyCalendarProperties(Notebook::Ptr notebook, DBOperation dbop)
+bool SqliteFormat::Private::modifyCalendarProperties(const Notebook &notebook,
+                                                     DBOperation dbop)
 {
-    QByteArray id(notebook->uid().toUtf8());
+    QByteArray id(notebook.uid().toUtf8());
     // In Update always delete all first then insert all
     if (dbop == DBUpdate && !deleteCalendarProperties(id)) {
         qCWarning(lcMkcal) << "failed to delete calendarproperties for notebook" << id;
@@ -1238,10 +1280,10 @@ bool SqliteFormat::Private::modifyCalendarProperties(Notebook::Ptr notebook, DBO
 
     bool success = true;
     if (dbop == DBInsert || dbop == DBUpdate) {
-        QList<QByteArray> properties = notebook->customPropertyKeys();
+        QList<QByteArray> properties = notebook.customPropertyKeys();
         for (QList<QByteArray>::ConstIterator it = properties.constBegin();
              it != properties.constEnd(); ++it) {
-            if (!insertCalendarProperty(id, *it, notebook->customProperty(*it).toUtf8())) {
+            if (!insertCalendarProperty(id, *it, notebook.customProperty(*it).toUtf8())) {
                 qCWarning(lcMkcal) << "failed to insert calendarproperty" << *it << "in notebook" << id;
                 success = false;
             }
@@ -1298,10 +1340,10 @@ error:
 }
 //@endcond
 
-Notebook::Ptr SqliteFormat::selectCalendars(sqlite3_stmt *stmt, bool *isDefault)
+Notebook* SqliteFormat::selectCalendars(sqlite3_stmt *stmt, bool *isDefault)
 {
     int rv = 0;
-    Notebook::Ptr notebook;
+    Notebook* notebook = nullptr;
     sqlite3_int64 date;
     QDateTime syncDate = QDateTime();
     QDateTime modifiedDate = QDateTime();
@@ -1328,7 +1370,7 @@ Notebook::Ptr SqliteFormat::selectCalendars(sqlite3_stmt *stmt, bool *isDefault)
         date = sqlite3_column_int64(stmt, 12);
         creationDate = fromOriginTime(date);
 
-        notebook = Notebook::Ptr(new Notebook(name, description));
+        notebook = new Notebook(name, description);
         notebook->setUid(id);
         notebook->setColor(color);
         notebook->setEventsAllowed(flags & SqliteFormat::AllowEvents);
@@ -1421,7 +1463,7 @@ Incidence::Ptr SqliteFormat::selectComponents(sqlite3_stmt *stmt1, QString &note
         QByteArray type((const char *)sqlite3_column_text(stmt1, 2));
         if (type == "Event") {
             // Set Event specific data.
-            Event::Ptr event = Event::Ptr(new Event());
+            Event::Ptr event(new Event());
             event->setAllDay(false);
 
             bool startIsDate;
@@ -1451,7 +1493,7 @@ Incidence::Ptr SqliteFormat::selectComponents(sqlite3_stmt *stmt1, QString &note
             incidence = event;
         } else if (type == "Todo") {
             // Set Todo specific data.
-            Todo::Ptr todo = Todo::Ptr(new Todo());
+            Todo::Ptr todo(new Todo());
             todo->setAllDay(false);
 
             bool startIsDate;
@@ -1477,7 +1519,7 @@ Incidence::Ptr SqliteFormat::selectComponents(sqlite3_stmt *stmt1, QString &note
             incidence = todo;
         } else if (type == "Journal") {
             // Set Journal specific data.
-            Journal::Ptr journal = Journal::Ptr(new Journal());
+            Journal::Ptr journal(new Journal());
 
             bool startIsDate;
             QDateTime start = getDateTime(this, stmt1, 5, &startIsDate);
@@ -1611,22 +1653,22 @@ Incidence::Ptr SqliteFormat::selectComponents(sqlite3_stmt *stmt1, QString &note
         }
 //    kDebug() << "loaded component for incidence" << incidence->uid() << "notebook" << notebook;
 
-        if (!d->selectCustomproperties(incidence, rowid)) {
+        if (!d->selectCustomproperties(incidence.data(), rowid)) {
             qCWarning(lcMkcal) << "failed to get customproperties for incidence" << incidence->uid();
         }
-        if (!d->selectAttendees(incidence, rowid)) {
+        if (!d->selectAttendees(incidence.data(), rowid)) {
             qCWarning(lcMkcal) << "failed to get attendees for incidence" << incidence->uid();
         }
-        if (!d->selectAlarms(incidence, rowid)) {
+        if (!d->selectAlarms(incidence.data(), rowid)) {
             qCWarning(lcMkcal) << "failed to get alarms for incidence" << incidence->uid();
         }
-        if (!d->selectRecursives(incidence, rowid)) {
+        if (!d->selectRecursives(incidence.data(), rowid)) {
             qCWarning(lcMkcal) << "failed to get recursive for incidence" << incidence->uid();
         }
-        if (!d->selectRdates(incidence, rowid)) {
+        if (!d->selectRdates(incidence.data(), rowid)) {
             qCWarning(lcMkcal) << "failed to get rdates for incidence" << incidence->uid();
         }
-        if (!d->selectAttachments(incidence, rowid)) {
+        if (!d->selectAttachments(incidence.data(), rowid)) {
             qCWarning(lcMkcal) << "failed to get attachments for incidence" << incidence->uid();
         }
 
@@ -1644,7 +1686,7 @@ error:
 }
 
 //@cond PRIVATE
-int SqliteFormat::Private::selectRowId(Incidence::Ptr incidence)
+int SqliteFormat::Private::selectRowId(const Incidence &incidence)
 {
     int rv = 0;
     int index = 1;
@@ -1660,13 +1702,13 @@ int SqliteFormat::Private::selectRowId(Incidence::Ptr incidence)
     qsize = sizeof(SELECT_ROWID_FROM_COMPONENTS_BY_UID_AND_RECURID);
 
     SL3_prepare_v2(mDatabase, query, qsize, &stmt, NULL);
-    u = incidence->uid().toUtf8();
+    u = incidence.uid().toUtf8();
     SL3_bind_text(stmt, index, u.constData(), u.length(), SQLITE_STATIC);
-    if (incidence->recurrenceId().isValid()) {
-        if (incidence->recurrenceId().timeSpec() == Qt::LocalTime) {
-            secsRecurId = mFormat->toLocalOriginTime(incidence->recurrenceId());
+    if (incidence.recurrenceId().isValid()) {
+        if (incidence.recurrenceId().timeSpec() == Qt::LocalTime) {
+            secsRecurId = mFormat->toLocalOriginTime(incidence.recurrenceId());
         } else {
-            secsRecurId = mFormat->toOriginTime(incidence->recurrenceId());
+            secsRecurId = mFormat->toOriginTime(incidence.recurrenceId());
         }
         SL3_bind_int64(stmt, index, secsRecurId);
     } else {
@@ -1686,7 +1728,7 @@ error:
     return rowid;
 }
 
-bool SqliteFormat::Private::selectCustomproperties(Incidence::Ptr &incidence, int rowid)
+bool SqliteFormat::Private::selectCustomproperties(Incidence *incidence, int rowid)
 {
     int rv = 0;
     int index = 1;
@@ -1718,7 +1760,7 @@ error:
     return false;
 }
 
-bool SqliteFormat::Private::selectRdates(Incidence::Ptr &incidence, int rowid)
+bool SqliteFormat::Private::selectRdates(Incidence *incidence, int rowid)
 {
     int rv = 0;
     int index = 1;
@@ -1763,7 +1805,7 @@ error:
     return false;
 }
 
-bool SqliteFormat::Private::selectRecursives(Incidence::Ptr &incidence, int rowid)
+bool SqliteFormat::Private::selectRecursives(Incidence *incidence, int rowid)
 {
     int  rv = 0;
     int  index = 1;
@@ -1798,7 +1840,7 @@ bool SqliteFormat::Private::selectRecursives(Incidence::Ptr &incidence, int rowi
                 recurrule->setStartDt(incidence->dtStart());
             else {
                 if (incidence->type() == Incidence::TypeTodo) {
-                    Todo::Ptr todo = incidence.staticCast<Todo>();
+                    Todo *todo = static_cast<Todo*>(incidence);
                     recurrule->setStartDt(todo->dtDue(true));
                 }
             }
@@ -1922,7 +1964,7 @@ error:
     return false;
 }
 
-bool SqliteFormat::Private::selectAlarms(Incidence::Ptr &incidence, int rowid)
+bool SqliteFormat::Private::selectAlarms(Incidence *incidence, int rowid)
 {
     int rv = 0;
     int index = 1;
@@ -2056,7 +2098,7 @@ error:
     return false;
 }
 
-bool SqliteFormat::Private::selectAttendees(Incidence::Ptr &incidence, int rowid)
+bool SqliteFormat::Private::selectAttendees(Incidence *incidence, int rowid)
 {
     int rv = 0;
     int index = 1;
@@ -2095,7 +2137,7 @@ error:
     return false;
 }
 
-bool SqliteFormat::Private::selectAttachments(Incidence::Ptr &incidence, int rowid)
+bool SqliteFormat::Private::selectAttachments(Incidence *incidence, int rowid)
 {
     int rv = 0;
     int index = 1;
@@ -2174,7 +2216,7 @@ error:
     return list;
 }
 
-bool SqliteFormat::Private::selectCalendarProperties(Notebook::Ptr notebook)
+bool SqliteFormat::Private::selectCalendarProperties(Notebook *notebook)
 {
     int rv = 0;
     int index = 1;

--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -96,11 +96,10 @@ public:
 
       @param notebook notebook to update
       @param dbop database operation
-      @param stmt prepared sqlite statement for calendars table
       @param isDefault if the notebook is the default one in the DB
       @return true if the operation was successful; false otherwise.
     */
-    bool modifyCalendars(const Notebook::Ptr &notebook, DBOperation dbop, sqlite3_stmt *stmt, bool isDefault);
+    bool modifyCalendars(const Notebook &notebook, DBOperation dbop, bool isDefault);
 
     /**
       Select notebooks from Calendars table.
@@ -109,7 +108,7 @@ public:
       @param isDefault true if the selected notebook is the DB default one
       @return the queried notebook.
     */
-    Notebook::Ptr selectCalendars(sqlite3_stmt *stmt, bool *isDefault);
+    Notebook* selectCalendars(sqlite3_stmt *stmt, bool *isDefault);
 
     /**
       Update incidence data in Components table.
@@ -119,10 +118,10 @@ public:
       @param dbop database operation
       @return true if the operation was successful; false otherwise.
     */
-    bool modifyComponents(const KCalendarCore::Incidence::Ptr &incidence, const QString &notebook,
+    bool modifyComponents(const KCalendarCore::Incidence &incidence, const QString &notebook,
                           DBOperation dbop);
 
-    bool purgeDeletedComponents(const KCalendarCore::Incidence::Ptr &incidence);
+    bool purgeDeletedComponents(const KCalendarCore::Incidence &incidence);
 
     /**
       Select incidences from Components table.

--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -104,11 +104,10 @@ public:
     /**
       Select notebooks from Calendars table.
 
-      @param stmt prepared sqlite statement for calendars table
       @param isDefault true if the selected notebook is the DB default one
       @return the queried notebook.
     */
-    Notebook* selectCalendars(sqlite3_stmt *stmt, bool *isDefault);
+    Notebook selectCalendars(bool *isDefault);
 
     /**
       Update incidence data in Components table.

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -1318,13 +1318,19 @@ bool SqliteStorage::Private::saveIncidences(QHash<QString, Incidence::Ptr> &list
 
     for (it = list.constBegin(); it != list.constEnd(); ++it) {
         QString notebookUid = mCalendar->notebook(*it);
-        if ((dbop == DBInsert || dbop == DBUpdate)
-            && !mStorage->isValidNotebook(notebookUid)) {
-            qCWarning(lcMkcal) << "invalid notebook - not saving incidence" << (*it)->uid();
-            continue;
-        } else {
-            (*savedIncidences) << *it;
+        if (dbop == DBInsert || dbop == DBUpdate) {
+            const Notebook &notebook = mStorage->notebook(notebookUid);
+            // Notice : we allow to save/delete incidences in a read-only
+            // notebook. The read-only flag is a hint only. This allows
+            // to update a marked as read-only notebook to reflect external
+            // changes.
+            if (notebook.isRunTimeOnly() ||
+                (mStorage->validateNotebooks() && !notebook.isValid())) {
+                qCWarning(lcMkcal) << "invalid notebook - not saving incidence" << (*it)->uid();
+                continue;
+            }
         }
+        (*savedIncidences) << *it;
 
         // lastModified is a public field of iCal RFC, so user should be
         // able to set its value to arbitrary date and time. This field is

--- a/src/sqlitestorage.h
+++ b/src/sqlitestorage.h
@@ -364,7 +364,7 @@ public:
 
 protected:
     bool loadNotebooks();
-    bool modifyNotebook(const Notebook::Ptr &nb, DBOperation dbop);
+    bool modifyNotebook(const Notebook &nb, DBOperation dbop);
 
 private:
     //@cond PRIVATE

--- a/tests/tst_load.cpp
+++ b/tests/tst_load.cpp
@@ -53,18 +53,18 @@ void tst_load::init()
     mStorage = ExtendedCalendar::defaultStorage(calendar);
     mStorage->open();
 
-    if (!mStorage->defaultNotebook()) {
-        Notebook::Ptr notebook(new Notebook({}, QString::fromLatin1("Default"), {}, {},
-                                            false, false, false, false, true));
+    if (mStorage->defaultNotebookId().isEmpty()) {
+        Notebook notebook({}, QString::fromLatin1("Default"), {}, {},
+                          false, false, false, false, true);
         QVERIFY(mStorage->setDefaultNotebook(notebook));
-        mCreatedNotebookUid = notebook->uid();
+        mCreatedNotebookUid = notebook.uid();
     }
 }
 
 void tst_load::cleanup()
 {
     if (!mCreatedNotebookUid.isEmpty()) {
-        QVERIFY(mStorage->deleteNotebook(mStorage->notebook(mCreatedNotebookUid)));
+        QVERIFY(mStorage->deleteNotebook(mCreatedNotebookUid));
     }
     mStorage.clear();
 }

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -58,9 +58,7 @@ void tst_storage::initTestCase()
 
 void tst_storage::cleanupTestCase()
 {
-    mKCal::Notebook::Ptr notebook = m_storage->notebook(NotebookId);
-    if (notebook)
-        QVERIFY(m_storage->deleteNotebook(notebook));
+    QVERIFY(m_storage->deleteNotebook(NotebookId));
 }
 
 void tst_storage::init()
@@ -70,9 +68,7 @@ void tst_storage::init()
 
 void tst_storage::cleanup()
 {
-    mKCal::Notebook::Ptr notebook = m_storage->notebook(NotebookId);
-    if (notebook)
-        QVERIFY(m_storage->deleteNotebook(notebook));
+    QVERIFY(m_storage->deleteNotebook(NotebookId));
 }
 
 void tst_storage::tst_timezone()
@@ -1264,19 +1260,18 @@ void tst_storage::tst_dissociateSingleOccurrence()
 // Accessor check for the deleted incidences.
 void tst_storage::tst_deleted()
 {
-    mKCal::Notebook::Ptr notebook =
-        mKCal::Notebook::Ptr(new mKCal::Notebook("123456789-deletion",
-                                                 "test notebook for deletion",
-                                                 QLatin1String(""),
-                                                 "#001122",
-                                                 false, // Not shared.
-                                                 true, // Is master.
-                                                 false, // Not synced to Ovi.
-                                                 false, // Writable.
-                                                 true, // Visible.
-                                                 QLatin1String(""),
-                                                 QLatin1String(""),
-                                                 0));
+    mKCal::Notebook notebook("123456789-deletion",
+                             "test notebook for deletion",
+                             QLatin1String(""),
+                             "#001122",
+                             false, // Not shared.
+                             true, // Is master.
+                             false, // Not synced to Ovi.
+                             false, // Writable.
+                             true, // Visible.
+                             QLatin1String(""),
+                             QLatin1String(""),
+                             0);
     m_storage->addNotebook(notebook);
 
     KCalendarCore::Event::Ptr event(new KCalendarCore::Event);
@@ -1296,12 +1291,12 @@ void tst_storage::tst_deleted()
     event3->setSummary("Re-created event");
     event3->setCreated(QDateTime::currentDateTimeUtc().addSecs(-3));
 
-    QVERIFY(m_calendar->addEvent(event, notebook->uid()));
-    QVERIFY(m_calendar->addEvent(event2, notebook->uid()));
-    QVERIFY(m_calendar->addEvent(event3, notebook->uid()));
+    QVERIFY(m_calendar->addEvent(event, notebook.uid()));
+    QVERIFY(m_calendar->addEvent(event2, notebook.uid()));
+    QVERIFY(m_calendar->addEvent(event3, notebook.uid()));
     QVERIFY(m_storage->save());
     reloadDb();
-    QVERIFY(m_storage->loadNotebookIncidences(notebook->uid()));
+    QVERIFY(m_storage->loadNotebookIncidences(notebook.uid()));
 
     KCalendarCore::Event::Ptr fetchEvent = m_calendar->event(event->uid());
     QVERIFY(fetchEvent);
@@ -1314,12 +1309,12 @@ void tst_storage::tst_deleted()
     // Deleted events are marked as deleted but remains in the DB
     QVERIFY(m_storage->save());
     reloadDb();
-    QVERIFY(m_storage->loadNotebookIncidences(notebook->uid()));
+    QVERIFY(m_storage->loadNotebookIncidences(notebook.uid()));
 
     KCalendarCore::Incidence::List deleted;
-    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(1), notebook->uid()));
+    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(1), notebook.uid()));
     QVERIFY(deleted.isEmpty());
-    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(-2), notebook->uid()));
+    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(-2), notebook.uid()));
     QCOMPARE(deleted.length(), 1);
     QCOMPARE(deleted[0]->uid(), event->uid());
     QCOMPARE(deleted[0]->nonKDECustomProperty("X-TEST-PROPERTY"), customValue);
@@ -1330,20 +1325,20 @@ void tst_storage::tst_deleted()
     // One can purge previously deleted events from DB
     QVERIFY(m_storage->purgeDeletedIncidences(deleted));
     deleted.clear();
-    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(-2), notebook->uid()));
+    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(-2), notebook.uid()));
     QCOMPARE(deleted.length(), 0);
 
     // One can purge deleted events from DB directly when they are
     // removed from a calendar.
-    QVERIFY(m_storage->loadNotebookIncidences(notebook->uid()));
+    QVERIFY(m_storage->loadNotebookIncidences(notebook.uid()));
     KCalendarCore::Event::Ptr fetchEvent2 = m_calendar->event(event2->uid());
     QVERIFY(fetchEvent2);
     QVERIFY(m_calendar->deleteIncidence(fetchEvent2));
     QVERIFY(m_storage->save(ExtendedStorage::PurgeDeleted));
     reloadDb();
-    QVERIFY(m_storage->loadNotebookIncidences(notebook->uid()));
+    QVERIFY(m_storage->loadNotebookIncidences(notebook.uid()));
     deleted.clear();
-    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(-2), notebook->uid()));
+    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(-2), notebook.uid()));
     QCOMPARE(deleted.length(), 0);
 
     // One can re-create event after deletion using the same UID
@@ -1352,16 +1347,16 @@ void tst_storage::tst_deleted()
     QVERIFY(m_calendar->deleteIncidence(fetchEvent3));
     QVERIFY(m_storage->save());
     reloadDb();
-    QVERIFY(m_storage->loadNotebookIncidences(notebook->uid()));
+    QVERIFY(m_storage->loadNotebookIncidences(notebook.uid()));
     // For instance a sync wants to re-create this because remote override local deletion
-    QVERIFY(m_calendar->addEvent(event3, notebook->uid()));
+    QVERIFY(m_calendar->addEvent(event3, notebook.uid()));
     QVERIFY(m_storage->save());
     reloadDb();
-    QVERIFY(m_storage->loadNotebookIncidences(notebook->uid()));
+    QVERIFY(m_storage->loadNotebookIncidences(notebook.uid()));
     fetchEvent3 = m_calendar->event(event3->uid());
     QVERIFY(fetchEvent3);
     deleted.clear();
-    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(-2), notebook->uid()));
+    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(-2), notebook.uid()));
     QCOMPARE(deleted.length(), 0);
 
     // Test notebook deletion (with non-purged deleted incidences)
@@ -1369,35 +1364,34 @@ void tst_storage::tst_deleted()
     QVERIFY(m_storage->save());
     reloadDb();
     deleted.clear();
-    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime(), notebook->uid()));
+    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime(), notebook.uid()));
     QCOMPARE(deleted.length(), 1);
-    QVERIFY(m_storage->deleteNotebook(m_storage->notebook(notebook->uid())));
+    QVERIFY(m_storage->deleteNotebook(notebook.uid()));
     reloadDb();
-    QVERIFY(m_storage->notebook(notebook->uid()).isNull());
+    QVERIFY(!m_storage->notebook(notebook.uid()).isValid());
     deleted.clear();
-    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime(), notebook->uid()));
+    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime(), notebook.uid()));
     QVERIFY(deleted.isEmpty());
     KCalendarCore::Incidence::List incidences;
-    QVERIFY(m_storage->allIncidences(&incidences, notebook->uid()));
+    QVERIFY(m_storage->allIncidences(&incidences, notebook.uid()));
     QVERIFY(incidences.isEmpty());
 }
 
 // Accessor check for modified incidences.
 void tst_storage::tst_modified()
 {
-    mKCal::Notebook::Ptr notebook =
-        mKCal::Notebook::Ptr(new mKCal::Notebook("123456789-modified",
-                                                 "test notebook",
-                                                 QLatin1String(""),
-                                                 "#001122",
-                                                 false, // Not shared.
-                                                 true, // Is master.
-                                                 false, // Not synced to Ovi.
-                                                 false, // Writable.
-                                                 true, // Visible.
-                                                 QLatin1String(""),
-                                                 QLatin1String(""),
-                                                 0));
+    mKCal::Notebook notebook("123456789-modified",
+                             "test notebook",
+                             QLatin1String(""),
+                             "#001122",
+                             false, // Not shared.
+                             true, // Is master.
+                             false, // Not synced to Ovi.
+                             false, // Writable.
+                             true, // Visible.
+                             QLatin1String(""),
+                             QLatin1String(""),
+                             0);
     m_storage->addNotebook(notebook);
 
     KCalendarCore::Event::Ptr event = KCalendarCore::Event::Ptr(new KCalendarCore::Event);
@@ -1429,19 +1423,18 @@ void tst_storage::tst_modified()
 // dissociation of a recurring event.
 void tst_storage::tst_inserted()
 {
-    mKCal::Notebook::Ptr notebook =
-        mKCal::Notebook::Ptr(new mKCal::Notebook("123456789-inserted",
-                                                 "test notebook",
-                                                 QLatin1String(""),
-                                                 "#001122",
-                                                 false, // Not shared.
-                                                 true, // Is master.
-                                                 false, // Not synced to Ovi.
-                                                 false, // Writable.
-                                                 true, // Visible.
-                                                 QLatin1String(""),
-                                                 QLatin1String(""),
-                                                 0));
+    mKCal::Notebook notebook("123456789-inserted",
+                             "test notebook",
+                             QLatin1String(""),
+                             "#001122",
+                             false, // Not shared.
+                             true, // Is master.
+                             false, // Not synced to Ovi.
+                             false, // Writable.
+                             true, // Visible.
+                             QLatin1String(""),
+                             QLatin1String(""),
+                             0);
     m_storage->addNotebook(notebook);
 
     KCalendarCore::Event::Ptr event = KCalendarCore::Event::Ptr(new KCalendarCore::Event);
@@ -1589,56 +1582,56 @@ void tst_storage::tst_deleteAllEvents()
 
 void tst_storage::tst_calendarProperties()
 {
-    Notebook::Ptr notebook = Notebook::Ptr(new Notebook(QStringLiteral("Notebook"), QString()));
+    Notebook notebook(QStringLiteral("Notebook"), QString());
 
-    QCOMPARE(notebook->customPropertyKeys().count(), 0);
+    QCOMPARE(notebook.customPropertyKeys().count(), 0);
     const QByteArray propKey("a key");
     const QString propValue = QStringLiteral("a value");
-    notebook->setCustomProperty(propKey, propValue);
-    QCOMPARE(notebook->customPropertyKeys().count(), 1);
-    QCOMPARE(notebook->customProperty(propKey), propValue);
+    notebook.setCustomProperty(propKey, propValue);
+    QCOMPARE(notebook.customPropertyKeys().count(), 1);
+    QCOMPARE(notebook.customProperty(propKey), propValue);
 
     QVERIFY(m_storage->addNotebook(notebook));
-    QString uid = notebook->uid();
+    QString uid = notebook.uid();
 
     reloadDb();
     notebook = m_storage->notebook(uid);
-    QVERIFY(notebook);
-    QCOMPARE(notebook->customPropertyKeys().count(), 1);
-    QCOMPARE(notebook->customProperty(propKey), propValue);
+    QVERIFY(notebook.isValid());
+    QCOMPARE(notebook.customPropertyKeys().count(), 1);
+    QCOMPARE(notebook.customProperty(propKey), propValue);
 
     const QByteArray propKey2("a second key");
     const QString propValue2 = QStringLiteral("another value");
-    notebook->setCustomProperty(propKey2, propValue2);
-    QCOMPARE(notebook->customPropertyKeys().count(), 2);
-    QCOMPARE(notebook->customProperty(propKey2), propValue2);
+    notebook.setCustomProperty(propKey2, propValue2);
+    QCOMPARE(notebook.customPropertyKeys().count(), 2);
+    QCOMPARE(notebook.customProperty(propKey2), propValue2);
 
     QVERIFY(m_storage->updateNotebook(notebook));
 
     reloadDb();
     notebook = m_storage->notebook(uid);
-    QVERIFY(notebook);
-    QCOMPARE(notebook->customPropertyKeys().count(), 2);
-    QCOMPARE(notebook->customProperty(propKey), propValue);
-    QCOMPARE(notebook->customProperty(propKey2), propValue2);
+    QVERIFY(notebook.isValid());
+    QCOMPARE(notebook.customPropertyKeys().count(), 2);
+    QCOMPARE(notebook.customProperty(propKey), propValue);
+    QCOMPARE(notebook.customProperty(propKey2), propValue2);
 
-    notebook->setCustomProperty(propKey2, QString());
-    QCOMPARE(notebook->customPropertyKeys().count(), 1);
-    QCOMPARE(notebook->customProperty(propKey), propValue);
-    QCOMPARE(notebook->customProperty(propKey2), QString());
+    notebook.setCustomProperty(propKey2, QString());
+    QCOMPARE(notebook.customPropertyKeys().count(), 1);
+    QCOMPARE(notebook.customProperty(propKey), propValue);
+    QCOMPARE(notebook.customProperty(propKey2), QString());
     QString defaultValue = QStringLiteral("default value");
-    QCOMPARE(notebook->customProperty(propKey2, defaultValue), defaultValue);
+    QCOMPARE(notebook.customProperty(propKey2, defaultValue), defaultValue);
 
     QVERIFY(m_storage->updateNotebook(notebook));
 
     reloadDb();
     notebook = m_storage->notebook(uid);
-    QVERIFY(notebook);
-    QCOMPARE(notebook->customPropertyKeys().count(), 1);
-    QCOMPARE(notebook->customProperty(propKey), propValue);
-    QCOMPARE(notebook->customProperty(propKey2), QString());
+    QVERIFY(notebook.isValid());
+    QCOMPARE(notebook.customPropertyKeys().count(), 1);
+    QCOMPARE(notebook.customProperty(propKey), propValue);
+    QCOMPARE(notebook.customProperty(propKey2), QString());
 
-    m_storage->deleteNotebook(notebook);
+    m_storage->deleteNotebook(notebook.uid());
 
     // Need to check by hand that property entries have been deleted.
     int rv;
@@ -1660,9 +1653,9 @@ void tst_storage::tst_calendarProperties()
 
 void tst_storage::tst_alarms()
 {
-    Notebook::Ptr notebook = Notebook::Ptr(new Notebook(QStringLiteral("Notebook for alarms"), QString()));
+    Notebook notebook(QStringLiteral("Notebook for alarms"), QString());
     QVERIFY(m_storage->addNotebook(notebook));
-    const QString uid = notebook->uid();
+    const QString uid = notebook.uid();
 
     const QDateTime dt = QDateTime::currentDateTimeUtc().addSecs(300);
     KCalendarCore::Event::Ptr ev = KCalendarCore::Event::Ptr(new KCalendarCore::Event);
@@ -1696,8 +1689,8 @@ void tst_storage::tst_alarms()
 #endif
 
     notebook = m_storage->notebook(uid);
-    QVERIFY(notebook);
-    notebook->setIsVisible(false);
+    QVERIFY(notebook.isValid());
+    notebook.setIsVisible(false);
     QVERIFY(m_storage->updateNotebook(notebook));
 
     // Adding an event in a non visible notebook should not add alarm.
@@ -1714,7 +1707,7 @@ void tst_storage::tst_alarms()
     m_calendar->close();
 
     // Switching the notebook to visible should activate all alarms.
-    notebook->setIsVisible(true);
+    notebook.setIsVisible(true);
     QVERIFY(m_storage->updateNotebook(notebook));
 #if defined(TIMED_SUPPORT)
     reply = timed.query_sync(map);
@@ -1723,7 +1716,7 @@ void tst_storage::tst_alarms()
 #endif
 
     // Switching the notebook to non visible should deactivate all alarms.
-    notebook->setIsVisible(false);
+    notebook.setIsVisible(false);
     QVERIFY(m_storage->updateNotebook(notebook));
 #if defined(TIMED_SUPPORT)
     reply = timed.query_sync(map);
@@ -1756,9 +1749,9 @@ void tst_storage::checkAlarms(const QSet<QDateTime> &alarms, const QString &uid)
 
 void tst_storage::tst_recurringAlarms()
 {
-    Notebook::Ptr notebook = Notebook::Ptr(new Notebook(QStringLiteral("Notebook for alarms"), QString()));
+    Notebook notebook(QStringLiteral("Notebook for recurring alarms"), QString());
     QVERIFY(m_storage->addNotebook(notebook));
-    const QString uid = notebook->uid();
+    const QString uid = notebook.uid();
 
     const QDateTime now = QDateTime::currentDateTimeUtc();
     const QDateTime dt = QDateTime(now.date().addDays(1), QTime(12, 00));
@@ -1807,22 +1800,22 @@ void tst_storage::tst_recurringAlarms()
     checkAlarms(QSet<QDateTime>() << exception->dtStart() << ev->dtStart().addDays(2), uid);
 
     notebook = m_storage->notebook(uid);
-    QVERIFY(notebook);
-    notebook->setIsVisible(false);
+    QVERIFY(notebook.isValid());
+    notebook.setIsVisible(false);
     QVERIFY(m_storage->updateNotebook(notebook));
 
     // Alarms have been removed for non visible notebook.
     checkAlarms(QSet<QDateTime>(), uid);
 
     notebook = m_storage->notebook(uid);
-    QVERIFY(notebook);
-    notebook->setIsVisible(true);
+    QVERIFY(notebook.isValid());
+    notebook.setIsVisible(true);
     QVERIFY(m_storage->updateNotebook(notebook));
 
     // Alarms are reset when visible is turned on.
     checkAlarms(QSet<QDateTime>() << exception->dtStart() << ev->dtStart().addDays(2), uid);
 
-    QVERIFY(m_storage->deleteNotebook(m_storage->notebook(uid)));
+    QVERIFY(m_storage->deleteNotebook(uid));
 }
 
 void tst_storage::tst_url_data()
@@ -2026,27 +2019,26 @@ void tst_storage::openDb(bool clear)
     m_storage = m_calendar->defaultStorage(m_calendar);
     m_storage->open();
 
-    mKCal::Notebook::Ptr notebook = m_storage->notebook(NotebookId);
+    mKCal::Notebook notebook = m_storage->notebook(NotebookId);
 
-    if (notebook.data() && clear) {
-        m_storage->deleteNotebook(notebook);
-        notebook.clear();
+    if (notebook.isValid() && clear) {
+        m_storage->deleteNotebook(notebook.uid());
+        notebook = Notebook();
     }
 
-    if (notebook.isNull()) {
-        notebook = mKCal::Notebook::Ptr(new mKCal::Notebook(NotebookId,
-                                                            "test notebook",
-                                                            QLatin1String(""),
-                                                            "#001122",
-                                                            false, // Not shared.
-                                                            true, // Is master.
-                                                            false, // Not synced to Ovi.
-                                                            false, // Writable.
-                                                            true, // Visible.
-                                                            QLatin1String(""),
-                                                            QLatin1String(""),
-                                                            0));
-        m_storage->addNotebook(notebook);
+    if (!notebook.isValid()) {
+        notebook = Notebook(NotebookId,
+                            "test notebook",
+                            QLatin1String(""),
+                            "#001122",
+                            false, // Not shared.
+                            true, // Is master.
+                            false, // Not synced to Ovi.
+                            false, // Writable.
+                            true, // Visible.
+                            QLatin1String(""),
+                            QLatin1String(""),
+                            0);
         m_storage->setDefaultNotebook(notebook);
     }
 


### PR DESCRIPTION
@pvuorela, this is a proposition to remove completely the Notebook::Ptr style, using either notebook ids or reference to notebooks.

This is done in steps:
* commit a498d17232a4f7ce3325eb2e1424fa5260af8913, keep API compatibility and use internally pointers (out) or references (in) at SqliteFormat level. The ownsership is taken by QSharedPointer() in SqliteStorage.
* commit 252bf4f1b3056b89aa15474389489d96bf9d5130, keep API compatibility and move notebook modifications (UID) out of ExtendedStorage so it can use const references on Notebooks later.
* commit f675e67daff5f93f297ee8a2fc27f6a284df1ebd, update ExtendedStorage API not to use Notebook::Ptr anymore. Internal storage is done with Notebook objects and they are copied on retrieval. I've changed also the ::deleteNotebook() API to take id instead of object. The same for the ::defaultNotebook(), it's now dealing with an id.
* commit 6d1128bf2ff3b016f81bb2a175f31d0d1f89c317, completely nuke Notebook::Ptr and Notebook::List definition from the API. It requires in addition to update all service plugins.

What do you think ? Applying these API changes will imply to update:
* nemo-qml-plugin-calendar, but only in the worker thread code,
* buteo-sync-plugin-caldav, nothing painfull,
* all Exchange plugins, no idea how painful it can be.

The changes in ExtendedStorage API will correct some weirdness (in my opinion) like the fact that you need to use the exact Notebook::Ptr object when updating, while any change to the DB file is actually detaching your Ptr from the one that is stored, thus making any update call fails.