### PR TITLE
[mkcal] Fix alarms for recurring events with exceptions.

### DIFF
--- a/tests/tst_storage.h
+++ b/tests/tst_storage.h
@@ -69,6 +69,7 @@ private slots:
     void tst_deleteAllEvents();
     void tst_calendarProperties();
     void tst_alarms();
+    void tst_recurringAlarms();
     void tst_url_data();
     void tst_url();
     void tst_color();
@@ -82,6 +83,7 @@ private:
     void openDb(bool clear = false);
     void reloadDb();
     void reloadDb(const QDate &from, const QDate &to);
+    void checkAlarms(const QSet<QDateTime> &alarms, const QString &uid) const;
 
     ExtendedCalendar::Ptr m_calendar;
     ExtendedStorage::Ptr m_storage;


### PR DESCRIPTION
@pvuorela, I noticed that cancelled occurrences were not removing their alarm and tried to fix it. Doing so, I understand that the code for recurring events in general was broken regarding the alarms. I've added a test demonstarting all possible failing situations:
- change time of the next occurrence : alarm will ring twice, one time on the normal time and one time for the new time,
- delete the next occurrence : alarm will ring anyway,
- cancel one occurrence, alarm will ring anyway.

That's because the parent does not contains anymore the EXDATE of the exceptions, so the getNextDateTime() in setAlarms() is always returning the next time in the recurrence without taking into account the exceptions. I'm proposing to correct this in the setAlarms() routine by adding the different cases of a recurring, an exception or a normal event. For the former, I'm twisting the `now` argument to be just before the actual next occurrence, taking into account the exception. For exception, I'm forcing a reset of the parent alarms in case it modifies it's visibility. For the later notihing is changed.

What do you think ?

