### PR TITLE
[mkcal] Correct mistake on starting time for alarm definition.

### DIFF
--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -804,7 +804,7 @@ void ExtendedStorage::Private::addAlarms(const Incidence::Ptr &incidence,
         }
 
         // nextTime() is returning time strictly later than its argument.
-        QDateTime alarmTime = alarm->nextTime(preTime.addDays(-1), true);
+        QDateTime alarmTime = alarm->nextTime(preTime.addSecs(-1), true);
         if (!alarmTime.isValid()) {
             continue;
         }


### PR DESCRIPTION
The laterThan was supposed to be moved one second (and
not one day) because nextTime() is returning time
strictly later than its argument.

@pvuorela, I'm sorry for this : / Technically the `.addDays(-1)` will work (that's why tests are passing, including the new ones), but only for recurrence with a period longer or equal to one day…