### PR TITLE
Protect against notebook storage changes for runtime only notebooks and other clean ups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(mkcal
-	VERSION 0.6.7
+	VERSION 0.6.10
 	DESCRIPTION "Mkcal calendar library")
 
 set(CMAKE_AUTOMOC ON)

--- a/rpm/mkcal-qt5.spec
+++ b/rpm/mkcal-qt5.spec
@@ -1,7 +1,7 @@
 Name:       mkcal-qt5
 
 Summary:    SQlite storage backend for KCalendarCore
-Version:    0.6.7
+Version:    0.6.10
 Release:    1
 License:    LGPLv2+
 URL:        https://github.com/sailfishos/mkcal

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -592,6 +592,8 @@ bool ExtendedStorage::isValidNotebook(const QString &notebookUid) const
 
 Notebook::Ptr ExtendedStorage::createDefaultNotebook(QString name, QString color)
 {
+    qCWarning(lcMkcal) << "Deprecated call to createDefaultNotebook(),"
+                       << "create a notebook and make it default with setDefaultNotebook() instead";
     if (name.isEmpty())
         name = "Default";
     if (color.isEmpty())

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -38,8 +38,6 @@
 #include <KCalendarCore/Calendar>
 using namespace KCalendarCore;
 
-#include <QtCore/QUuid>
-
 #ifdef TIMED_SUPPORT
 # include <timed-qt5/interface.h>
 # include <timed-qt5/event-declarations.h>
@@ -421,12 +419,6 @@ void ExtendedStorage::setUpdated(const KCalendarCore::Incidence::List &added,
 
 bool ExtendedStorage::addNotebook(const Notebook::Ptr &nb)
 {
-    if (nb->uid().length() < 7) {
-        // Cannot accept this id, create better one.
-        QString uid(QUuid::createUuid().toString());
-        nb->setUid(uid.mid(1, uid.length() - 2));
-    }
-
     if (!nb || d->mNotebooks.contains(nb->uid())) {
         return false;
     }
@@ -595,14 +587,11 @@ bool ExtendedStorage::isValidNotebook(const QString &notebookUid)
 
 Notebook::Ptr ExtendedStorage::createDefaultNotebook(QString name, QString color)
 {
-    // Could use QUuid::WithoutBraces when moving to Qt5.11.
-    const QString uid(QUuid::createUuid().toString());
     if (name.isEmpty())
         name = "Default";
     if (color.isEmpty())
         color = "#0000FF";
-    Notebook::Ptr nbDefault(new Notebook(uid.mid(1, uid.length() - 2), name, QString(), color,
-                                         false, true, false, false, true));
+    Notebook::Ptr nbDefault(new Notebook(name, QString(), color));
     return setDefaultNotebook(nbDefault) ? nbDefault : Notebook::Ptr();
 }
 

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -568,7 +568,7 @@ public:
       @param uid notebook uid
       @return pointer to notebook
     */
-    Notebook::Ptr notebook(const QString &uid);
+    Notebook::Ptr notebook(const QString &uid) const;
 
     /**
       List all notebooks.
@@ -593,7 +593,7 @@ public:
 
       @return true to validate notebooks
     */
-    bool validateNotebooks();
+    bool validateNotebooks() const;
 
     /**
       Returns true if the given notebook is valid for the storage.
@@ -602,7 +602,7 @@ public:
       @param notebookUid notebook uid
       @return true or false
     */
-    bool isValidNotebook(const QString &notebookUid);
+    bool isValidNotebook(const QString &notebookUid) const;
 
     // Alarm Methods //
 

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -571,15 +571,6 @@ public:
     Notebook::Ptr notebook(const QString &uid);
 
     /**
-      Search for notebook in a list.
-
-      @param list notebook list
-      @param uid notebook uid
-      @return pointer to notebook
-    */
-    Notebook::Ptr notebook(Notebook::List &list, const QString &uid);
-
-    /**
       List all notebooks.
 
       @return list of notebooks

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -623,6 +623,9 @@ public:
       Creates and sets a default notebook. Usually called for an empty
       calendar.
 
+      Notice: deprecated since 0.6.10. Instead, create a notebook
+              and call setDefaultNotebook().
+
       @param name notebook's name, if empty default used
       @param color notebook's color in format "#FF0042", if empty default used
       @return pointer to the created notebook

--- a/src/notebook.cpp
+++ b/src/notebook.cpp
@@ -36,6 +36,7 @@ using namespace KCalendarCore;
 
 #include <QtCore/QStringList>
 #include <QtCore/QHash>
+#include <QtCore/QUuid>
 
 using namespace mKCal;
 
@@ -81,16 +82,17 @@ class mKCal::Notebook::Private
 {
 public:
     Private()
-        : mFlags(DEFAULT_NOTEBOOK_FLAGS),
-          mSyncDate(QDateTime()),
-          mPluginName(QString()),
-          mAccount(QString()),
-          mAttachmentSize(-1),
-          mModifiedDate(QDateTime()),
-          mSharedWith(QStringList()),
-          mSyncProfile(QString()),
-          mCreationDate(QDateTime())
     {}
+
+    Private(const QString &uid)
+        : mUid(uid)
+    {
+        if (mUid.length() < 7) {
+            // Could use QUuid::WithoutBraces when moving to Qt5.11.
+            const QString uid(QUuid::createUuid().toString());
+            mUid = uid.mid(1, uid.length() - 2);
+        }
+    }
 
     Private(const Private &other)
         : mUid(other.mUid),
@@ -113,11 +115,11 @@ public:
     QString mName;
     QString mDescription;
     QString mColor;
-    int mFlags;
+    int mFlags = DEFAULT_NOTEBOOK_FLAGS;
     QDateTime mSyncDate;
     QString mPluginName;
     QString mAccount;
-    int mAttachmentSize;
+    int mAttachmentSize = -1;
     QDateTime mModifiedDate;
     QStringList mSharedWith;
     QString mSyncProfile;
@@ -131,20 +133,20 @@ Notebook::Notebook()
 {
 }
 
-Notebook::Notebook(const QString &name, const QString &description)
-    : d(new Notebook::Private())
+Notebook::Notebook(const QString &name, const QString &description, const QString &color)
+    : d(new Notebook::Private(QString()))
 {
     setName(name);
     setDescription(description);
+    setColor(color);
 }
 
 Notebook::Notebook(const QString &uid, const QString &name,
                    const QString &description, const QString &color,
                    bool isShared, bool isMaster, bool isSynced,
                    bool isReadOnly, bool isVisible)
-    : d(new Notebook::Private())
+    : d(new Notebook::Private(uid))
 {
-    setUid(uid);
     setName(name);
     setDescription(description);
     setColor(color);
@@ -160,9 +162,8 @@ Notebook::Notebook(const QString &uid, const QString &name,
                    bool isShared, bool isMaster, bool isSynced,
                    bool isReadOnly, bool isVisible, const QString &pluginName,
                    const QString &account, int attachmentSize)
-    : d(new Notebook::Private())
+    : d(new Notebook::Private(uid))
 {
-    setUid(uid);
     setName(name);
     setDescription(description);
     setColor(color);

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -65,7 +65,8 @@ public:
     */
     explicit Notebook();
 
-    explicit Notebook(const QString &name, const QString &description);
+    explicit Notebook(const QString &name, const QString &description,
+                      const QString &color = {});
 
     explicit Notebook(const QString &uid, const QString &name,
                       const QString &description, const QString &color,

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -63,27 +63,27 @@ public:
     /**
       Constructs a new Notebook object.
     */
-    explicit Notebook();
+    Notebook();
 
-    explicit Notebook(const QString &name, const QString &description,
-                      const QString &color = {});
+    Notebook(const QString &name, const QString &description,
+             const QString &color = {});
 
-    explicit Notebook(const QString &uid, const QString &name,
-                      const QString &description, const QString &color,
-                      bool isShared, bool isMaster, bool oviSync,
-                      bool isReadOnly, bool isVisible);
+    Notebook(const QString &uid, const QString &name,
+             const QString &description, const QString &color,
+             bool isShared, bool isMaster, bool oviSync,
+             bool isReadOnly, bool isVisible);
 
-    explicit Notebook(const QString &uid, const QString &name,
-                      const QString &description, const QString &color,
-                      bool isShared, bool isMaster, bool isSynchronized,
-                      bool isReadOnly, bool isVisible, const QString &pluginName,
-                      const QString &account, int attachmentSize);
+    Notebook(const QString &uid, const QString &name,
+             const QString &description, const QString &color,
+             bool isShared, bool isMaster, bool isSynchronized,
+             bool isReadOnly, bool isVisible, const QString &pluginName,
+             const QString &account, int attachmentSize);
 
     /**
       Constructs an Notebook as a copy of another Notebook object.
       @param n is the Notebook to copy.
     */
-    explicit Notebook(const Notebook &n);
+    Notebook(const Notebook &n);
 
     /**
       Destructor.

--- a/src/servicehandler.cpp
+++ b/src/servicehandler.cpp
@@ -100,12 +100,13 @@ bool ServiceHandlerPrivate::executePlugin(ExecutedPlugin action, const Incidence
         notebookUid = notebook->uid();
     } else {
         notebookUid = calendar->notebook(invitation);
-        if (storage->isValidNotebook(notebookUid)) {
-            accountNotebook = storage->notebook(notebookUid);
-        }
+        accountNotebook = storage->notebook(notebookUid);
     }
 
-    if (accountNotebook.isNull()) {
+    if (accountNotebook.isNull() ||
+        accountNotebook->isRunTimeOnly() ||
+        accountNotebook->isReadOnly() ||
+        !calendar->hasValidNotebook(notebookUid)) {
         qCWarning(lcMkcal) << "No notebook available for invitation plugin to use";
         return false;
     }

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -215,7 +215,6 @@ bool SqliteStorage::open()
     int rv;
     char *errmsg = NULL;
     const char *query = NULL;
-    Notebook::List list;
 
     if (d->mDatabase) {
         return false;
@@ -269,10 +268,16 @@ bool SqliteStorage::open()
         goto error;
     }
 
-    list = notebooks();
-    if (list.isEmpty()) {
+    if (notebooks().isEmpty()) {
         qCDebug(lcMkcal) << "Storage is empty, initializing";
-        createDefaultNotebook();
+        Notebook::Ptr defaultNb(new Notebook(QString::fromLatin1("Default"),
+                                             QString(),
+                                             QString::fromLatin1("#0000FF")));
+        if (!setDefaultNotebook(defaultNb)) {
+            qCWarning(lcMkcal) << "Unable to add a default notebook.";
+            close();
+            return false;
+        }
     }
 
     return true;


### PR DESCRIPTION
@pvuorela, this is a selection of commits from #30, commits that don't change the API and may be reviewed independently.

Once we agree on this I'll make another commit with (simple) API break, like:
- remove completely the `isValidNotebook()` as we discussed in #30. It requires a fix in the contact birthday plugin and in the nemo QML calendar plugin, as far as I know.
- change the `deleteNotebook()` API to use a notebook uid and not a notebook pointer.
- change the `defaultNotebook()` and `setDefaultNotebook()` to use uid instead of a notebook pointer.

These API breaks are still less invasive than completely suppressing the ::Ptr part for Notebooks, but they make the ExtendedStorage API simpler and don't require to load Notebook::Ptr from outside mKCal when uids are enough.

What do you think ?