### PR TITLE
[mkcal] Fix issue on recurring alarms.

### DIFF
--- a/tools/mkcaltool/mkcaltool.cpp
+++ b/tools/mkcaltool/mkcaltool.cpp
@@ -37,7 +37,7 @@ int MkcalTool::resetAlarms(const QString &notebookUid, const QString &eventUid)
     mKCal::ExtendedCalendar::Ptr cal(new mKCal::ExtendedCalendar(QTimeZone::systemTimeZone()));
     mKCal::ExtendedStorage::Ptr storage = cal->defaultStorage(cal);
     storage->open();
-    if (!storage->load(eventUid)) {
+    if (!storage->loadSeries(eventUid)) {
         qWarning() << "Unable to load event" << eventUid << "from notebook" << notebookUid;
         return 1;
     }


### PR DESCRIPTION
Commit f295c422 introduced a fix for recurring alarms with exceptions. The fix was written in the timed
plugin code to use the full recurring incidence
with exceptions to compute the next alarm occurrence. This code is unit tested, but the place where it is called (the mkcaltool helper) was not updated to
properly load the full incidence description,
including exceptions.

@pvuorela, this is a quick fix for the still existing issue with recurring alarms and exceptions. As mentioned in the commit message, I forgot to properly load the exception defintions from the helper tool that actually set the next alarm on device when discarding the current one.