### PR TITLE
[mkcal] Reset alarms for recurring events when an exception is removed.

### DIFF
--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -1778,16 +1778,26 @@ void tst_storage::tst_recurringAlarms()
     KCalendarCore::Incidence::Ptr exception = KCalendarCore::Calendar::createException(ev, ev->dtStart());
     exception->setDtStart(dt.addSecs(300));
     QVERIFY(m_calendar->addEvent(exception.staticCast<KCalendarCore::Event>(), uid));
+    KCalendarCore::Incidence::Ptr exception2 = KCalendarCore::Calendar::createException(ev, ev->dtStart().addDays(5));
+    exception2->setDtStart(dt.addDays(5).addSecs(300));
+    QVERIFY(m_calendar->addEvent(exception2.staticCast<KCalendarCore::Event>(), uid));
     QVERIFY(m_storage->save());
 
-    // Exception on the next occurrence
-    checkAlarms(QSet<QDateTime>() << exception->dtStart() << ev->dtStart().addDays(1), uid);
+    // Exception on the next occurrence, and second exception on the 5th occurence
+    checkAlarms(QSet<QDateTime>() << exception->dtStart()
+                << ev->dtStart().addDays(1) << exception2->dtStart(), uid);
 
     QVERIFY(m_calendar->deleteIncidence(exception));
+    QVERIFY(m_calendar->deleteIncidence(exception2));
+    QVERIFY(m_storage->save());
+
+    // Exception was deleted
+    checkAlarms(QSet<QDateTime>() << ev->dtStart(), uid);
+
     ev->recurrence()->addExDateTime(ev->dtStart());
     QVERIFY(m_storage->save());
 
-    // Exception deleted and exdate added on the next occurrence
+    // exdate added
     checkAlarms(QSet<QDateTime>() << ev->dtStart().addDays(1), uid);
 
     exception = KCalendarCore::Calendar::createException(ev, ev->dtStart().addDays(1));


### PR DESCRIPTION
@pvuorela , yet another alarm issue for recurring events with exceptions. I wrongly assumed that removing an exception in the QML bindings always add an EXDATE for that occurrence. So I initially designed the tests with this assumption in mind in mkcal. But that's not true (anymore?) : for instance, create a recurring event, create an exception by changing the start time for instance on one occurrence, and then delete the exception. The normal occurrence is back, because no EXDATE is set. Delete the normal occurrence and an EXDATE is set.

As you can see from the old test here, the exception deletion and the EXDATE addition was executed at the same time, while if you run the test with two separate actions, and testing the alarm value in-between (as newly implemented), you observe that the alarm is assuming the EXDATE when the exception is deleted and the test is failing.

That's because how the alarms are implemented : there is one alarm for the parent (taken into account the exceptions are EXDATEs) and one alarm for each exception. Removing one exception without assuming that it is replaced by an EXDATE thus require to reset the alarm of the parent. That's what the current patch is doing.