### PR TITLE
[mkcal] Delete exception on parent delete.

### DIFF
--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -120,7 +120,7 @@ public:
       @return true if the operation was successful; false otherwise.
     */
     bool modifyComponents(const KCalendarCore::Incidence::Ptr &incidence, const QString &notebook,
-                          DBOperation dbop);
+                          DBOperation dbop, KCalendarCore::Incidence::List *modifiedIncidences);
 
     bool purgeDeletedComponents(const KCalendarCore::Incidence::Ptr &incidence);
 
@@ -444,6 +444,10 @@ private:
 "select * from Components where Notebook=? and DateDeleted=0"
 #define SELECT_ROWID_FROM_COMPONENTS_BY_UID_AND_RECURID \
 "select ComponentId from Components where UID=? and RecurId=? and DateDeleted=0"
+#define SELECT_ROWID_FROM_COMPONENTS_BY_UID \
+"select ComponentId from Components where UID=? and RecurId<>0 and DateDeleted=0"
+#define SELECT_COMPONENTS_BY_ROWID \
+"select * from Components where ComponentId = ?"
 #define SELECT_COMPONENTS_BY_UNCOMPLETED_TODOS \
 "select * from Components where Type='Todo' and DateCompleted=0 and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_COMPLETED_TODOS_AND_DATE \

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -1357,7 +1357,6 @@ bool SqliteStorage::Private::saveIncidences(QHash<QString, Incidence::Ptr> &list
                 continue;
             }
          }
-         (*savedIncidences) << *it;
 
         // lastModified is a public field of iCal RFC, so user should be
         // able to set its value to arbitrary date and time. This field is
@@ -1368,15 +1367,9 @@ bool SqliteStorage::Private::saveIncidences(QHash<QString, Incidence::Ptr> &list
             (*it)->setLastModified(QDateTime::currentDateTimeUtc());
         }
         qCDebug(lcMkcal) << operation << "incidence" << (*it)->uid() << "notebook" << notebookUid;
-        if (!mFormat->modifyComponents(*it, notebookUid, dbop)) {
+        if (!mFormat->modifyComponents(*it, notebookUid, dbop, savedIncidences)) {
             qCWarning(lcMkcal) << sqlite3_errmsg(mDatabase) << "for incidence" << (*it)->uid();
             errors++;
-        } else  if (dbop == DBInsert) {
-            // Don't leave deleted events with the same UID/recID.
-            if (!mFormat->purgeDeletedComponents(*it)) {
-                qCWarning(lcMkcal) << "cannot purge deleted components on insertion.";
-                errors += 1;
-            }
         }
     }
 


### PR DESCRIPTION
Ensure that no orphan exceptions are left in the
database when deleting a recurring incidence by
always deleting exceptions, even if not loaded
in memory in the calendar.

This also allows code using mKCal not to always
call loadSeries() before deleting a recurring
incidence.

@pvuorela , this is also a low priority PR. I'm trying with such commits to guarantee that the DB is consistent even if the calling code don't know anything about internal storing of exceptions or mark as deleted incidences. The check and operations are now done in one place : the modifyComponent() call, where one can add, update or delete an incidence.

When you have a moment, give me your opinion. It should help to clean here and there in QML bindings or sync plugin various places where one ensure that a full series is loaded before deleting the parent.