### PR TITLE
[mkcal] Fix Notebook default ctor not creating a valid notebook. JB#59696

### DIFF
--- a/src/notebook.cpp
+++ b/src/notebook.cpp
@@ -81,9 +81,6 @@ do {                                              \
 class mKCal::Notebook::Private
 {
 public:
-    Private()
-    {}
-
     Private(const QString &uid)
         : mUid(uid)
     {
@@ -129,7 +126,7 @@ public:
 //@endcond
 
 Notebook::Notebook()
-    : d(new Notebook::Private())
+    : d(new Notebook::Private(QString()))
 {
 }
 


### PR DESCRIPTION
Commit aacdc880b3 moved the uid generation from ExtendedStorage to Notebook. However the default ctor was left not calling the uid generation, thus sync plugins creating plain Notebook instance and then setting the properties was failing.

@Tomin1 @dcaliste 