### PR TITLE
[mkcal] Avoid deprecated Incidence::setHasGeo. Fixes JB#59699

### DIFF
--- a/src/sqliteformat.cpp
+++ b/src/sqliteformat.cpp
@@ -1527,9 +1527,6 @@ Incidence::Ptr SqliteFormat::selectComponents(sqlite3_stmt *stmt1, QString &note
 
         incidence->setGeoLatitude(sqlite3_column_double(stmt1, index++));
         incidence->setGeoLongitude(sqlite3_column_double(stmt1, index++));
-        if (incidence->geoLatitude() != INVALID_LATLON) {
-            incidence->setHasGeo(true);
-        }
 
         incidence->setPriority(sqlite3_column_int(stmt1, index++));
 

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -1567,7 +1567,6 @@ void tst_storage::tst_deleteAllEvents()
 
     KCalendarCore::Event::Ptr ev = KCalendarCore::Event::Ptr(new KCalendarCore::Event);
     ev->setLastModified(QDateTime::currentDateTimeUtc().addSecs(-42));
-    ev->setHasGeo(true);
     ev->setGeoLatitude(42.);
     ev->setGeoLongitude(42.);
     ev->setDtStart(QDateTime(QDate(2019, 10, 10)));


### PR DESCRIPTION
Setting coordinate implicitly sets this. Also setHasGeo(true) is a no-op on kf5-calendarcore.

@Tomin1 @dcaliste @llewelld 