### PR TITLE
[mkcal] Add DB support for thisAndFuture incidence attribute.

### DIFF
--- a/rpm/mkcal-qt5.spec
+++ b/rpm/mkcal-qt5.spec
@@ -1,7 +1,7 @@
 Name:       mkcal-qt5
 
 Summary:    SQlite storage backend for KCalendarCore
-Version:    0.6.10
+Version:    0.7.2
 Release:    1
 License:    LGPLv2+
 URL:        https://github.com/sailfishos/mkcal

--- a/src/sqliteformat.cpp
+++ b/src/sqliteformat.cpp
@@ -621,6 +621,7 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
         }
         SL3_bind_int(stmt1, index, percentComplete);
         SL3_bind_date_time(this, stmt1, index, effectiveDtCompleted, incidence->allDay());
+        SL3_bind_int(stmt1, index, incidence->thisAndFuture());
 
         colorstr = incidence->color().toUtf8();
         SL3_bind_text(stmt1, index, colorstr.constData(), colorstr.length(), SQLITE_STATIC);
@@ -1593,6 +1594,8 @@ Incidence::Ptr SqliteFormat::selectComponents(sqlite3_stmt *stmt1, QString &note
         }
 
         index++; //DateDeleted
+
+        incidence->setThisAndFuture(sqlite3_column_int(stmt1, index++));
 
         QString colorstr = QString::fromUtf8((const char *) sqlite3_column_text(stmt1, index++));
         if (!colorstr.isEmpty()) {

--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -307,7 +307,7 @@ private:
 //extra1: used to store the color of a single component.
 
 #define CREATE_COMPONENTS \
-  "CREATE TABLE IF NOT EXISTS Components(ComponentId INTEGER PRIMARY KEY AUTOINCREMENT, Notebook TEXT, Type TEXT, Summary TEXT, Category TEXT, DateStart INTEGER, DateStartLocal INTEGER, StartTimeZone TEXT, HasDueDate INTEGER, DateEndDue INTEGER, DateEndDueLocal INTEGER, EndDueTimeZone TEXT, Duration INTEGER, Classification INTEGER, Location TEXT, Description TEXT, Status INTEGER, GeoLatitude REAL, GeoLongitude REAL, Priority INTEGER, Resources TEXT, DateCreated INTEGER, DateStamp INTEGER, DateLastModified INTEGER, Sequence INTEGER, Comments TEXT, Attachments TEXT, Contact TEXT, InvitationStatus INTEGER, RecurId INTEGER, RecurIdLocal INTEGER, RecurIdTimeZone TEXT, RelatedTo TEXT, URL TEXT, UID TEXT, Transparency INTEGER, LocalOnly INTEGER, Percent INTEGER, DateCompleted INTEGER, DateCompletedLocal INTEGER, CompletedTimeZone TEXT, DateDeleted INTEGER, extra1 STRING, extra2 STRING, extra3 INTEGER)"
+  "CREATE TABLE IF NOT EXISTS Components(ComponentId INTEGER PRIMARY KEY AUTOINCREMENT, Notebook TEXT, Type TEXT, Summary TEXT, Category TEXT, DateStart INTEGER, DateStartLocal INTEGER, StartTimeZone TEXT, HasDueDate INTEGER, DateEndDue INTEGER, DateEndDueLocal INTEGER, EndDueTimeZone TEXT, Duration INTEGER, Classification INTEGER, Location TEXT, Description TEXT, Status INTEGER, GeoLatitude REAL, GeoLongitude REAL, Priority INTEGER, Resources TEXT, DateCreated INTEGER, DateStamp INTEGER, DateLastModified INTEGER, Sequence INTEGER, Comments TEXT, Attachments TEXT, Contact TEXT, InvitationStatus INTEGER, RecurId INTEGER, RecurIdLocal INTEGER, RecurIdTimeZone TEXT, RelatedTo TEXT, URL TEXT, UID TEXT, Transparency INTEGER, LocalOnly INTEGER, Percent INTEGER, DateCompleted INTEGER, DateCompletedLocal INTEGER, CompletedTimeZone TEXT, DateDeleted INTEGER, thisAndFuture INTEGER, extra1 STRING, extra2 STRING, extra3 INTEGER)"
 
 //Extra fields added for future use in case they are needed. They will be documented here
 //So we can add something without breaking the schema and not adding tables
@@ -355,7 +355,7 @@ private:
 #define INSERT_CALENDARS \
 "insert into Calendars values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', '')"
 #define INSERT_COMPONENTS \
-"insert into Components values (NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, '', 0)"
+"insert into Components values (NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, '', 0)"
 #define INSERT_CUSTOMPROPERTIES \
 "insert into Customproperties values (?, ?, ?, ?)"
 #define INSERT_CALENDARPROPERTIES \
@@ -378,7 +378,7 @@ private:
 #define UPDATE_CALENDARS \
 "update Calendars set Name=?, Description=?, Color=?, Flags=?, syncDate=?, pluginName=?, account=?, attachmentSize=?, modifiedDate=?, sharedWith=?, syncProfile=?, createdDate=? where CalendarId=?"
 #define UPDATE_COMPONENTS \
-"update Components set Notebook=?, Type=?, Summary=?, Category=?, DateStart=?, DateStartLocal=?, StartTimeZone=?, HasDueDate=?, DateEndDue=?, DateEndDueLocal=?, EndDueTimeZone=?, Duration=?, Classification=?, Location=?, Description=?, Status=?, GeoLatitude=?, GeoLongitude=?, Priority=?, Resources=?, DateCreated=?, DateStamp=?, DateLastModified=?, Sequence=?, Comments=?, Attachments=?, Contact=?, RecurId=?, RecurIdLocal=?, RecurIdTimeZone=?, RelatedTo=?, URL=?, UID=?, Transparency=?, LocalOnly=?, Percent=?, DateCompleted=?, DateCompletedLocal=?, CompletedTimeZone=?, extra1=? where ComponentId=?"
+"update Components set Notebook=?, Type=?, Summary=?, Category=?, DateStart=?, DateStartLocal=?, StartTimeZone=?, HasDueDate=?, DateEndDue=?, DateEndDueLocal=?, EndDueTimeZone=?, Duration=?, Classification=?, Location=?, Description=?, Status=?, GeoLatitude=?, GeoLongitude=?, Priority=?, Resources=?, DateCreated=?, DateStamp=?, DateLastModified=?, Sequence=?, Comments=?, Attachments=?, Contact=?, RecurId=?, RecurIdLocal=?, RecurIdTimeZone=?, RelatedTo=?, URL=?, UID=?, Transparency=?, LocalOnly=?, Percent=?, DateCompleted=?, DateCompletedLocal=?, CompletedTimeZone=?, thisAndFuture=?, extra1=? where ComponentId=?"
 #define UPDATE_COMPONENTS_AS_DELETED \
 "update Components set DateDeleted=? where ComponentId=?"
 //"update Components set DateDeleted=strftime('%s','now') where ComponentId=?"

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -87,7 +87,7 @@ static const char *createStatements[] =
     INDEX_ATTACHMENTS,
     INDEX_CALENDARPROPERTIES,
     "PRAGMA foreign_keys = ON",
-    "PRAGMA user_version = 1"
+    "PRAGMA user_version = 2"
 };
 
 /**
@@ -257,6 +257,15 @@ bool SqliteStorage::open()
                     "              SELECT ComponentId, Email, Name, 0, Role, PartStat, Rsvp, DelegatedTo, DelegatedFrom "
                     "              FROM ATTENDEE WHERE isOrganizer=1";
             SL3_exec(d->mDatabase);
+
+            version = 1;
+        }
+        if (version == 1) {
+            qCWarning(lcMkcal) << "Migrating mkcal database to version 2";
+            query = "ALTER TABLE Components ADD COLUMN thisAndFuture INTEGER";
+            SL3_exec(d->mDatabase);
+
+            version = 2;
         }
     }
 

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -1866,6 +1866,28 @@ void tst_storage::tst_url()
     QCOMPARE(fetchEvent->url(), url);
 }
 
+void tst_storage::tst_thisAndFuture()
+{
+    auto event = KCalendarCore::Event::Ptr(new KCalendarCore::Event);
+    event->setDtStart(QDateTime(QDate(2022, 1, 17), QTime(10, 0)));
+    event->recurrence()->setDaily(1);
+    QVERIFY(m_calendar->addEvent(event, NotebookId));
+    auto exception = m_calendar->createException(event, event->dtStart().addDays(3), true);
+    exception->setDtStart(QDateTime(QDate(2022, 1, 20), QTime(9, 0)));
+    QVERIFY(m_calendar->addIncidence(exception, NotebookId));
+
+    m_storage->save();
+    reloadDb();
+
+    auto fetchEvent = m_calendar->event(event->uid());
+    QVERIFY(fetchEvent);
+    QVERIFY(!fetchEvent->thisAndFuture());
+    auto fetchException = m_calendar->event(exception->uid(),
+                                            exception->recurrenceId());
+    QVERIFY(fetchException);
+    QVERIFY(fetchException->thisAndFuture());
+}
+
 void tst_storage::tst_color()
 {
     const QString &red = QString::fromLatin1("red");

--- a/tests/tst_storage.h
+++ b/tests/tst_storage.h
@@ -72,6 +72,7 @@ private slots:
     void tst_recurringAlarms();
     void tst_url_data();
     void tst_url();
+    void tst_thisAndFuture();
     void tst_color();
     void tst_addIncidence();
     void tst_attachments();


### PR DESCRIPTION
@pvuorela: this may become handy if we plan to support changes from a point in time for recurring events at UI level.

There is no test for the migration code path. I run it by hand though on an old database and it seems that the new column is correctly added. And rerunning it on the upgraded database didn't trigger the migration path anymore.