### PR TITLE
DB migration and thisAndFuture addition

### DIFF
--- a/src/sqliteformat.cpp
+++ b/src/sqliteformat.cpp
@@ -621,10 +621,11 @@ bool SqliteFormat::modifyComponents(const Incidence::Ptr &incidence, const QStri
         }
         SL3_bind_int(stmt1, index, percentComplete);
         SL3_bind_date_time(this, stmt1, index, effectiveDtCompleted, incidence->allDay());
-        SL3_bind_int(stmt1, index, incidence->thisAndFuture());
 
         colorstr = incidence->color().toUtf8();
         SL3_bind_text(stmt1, index, colorstr.constData(), colorstr.length(), SQLITE_STATIC);
+
+        SL3_bind_int(stmt1, index, incidence->thisAndFuture());
 
         if (dbop == DBUpdate)
             SL3_bind_int(stmt1, index, rowid);
@@ -1595,12 +1596,14 @@ Incidence::Ptr SqliteFormat::selectComponents(sqlite3_stmt *stmt1, QString &note
 
         index++; //DateDeleted
 
-        incidence->setThisAndFuture(sqlite3_column_int(stmt1, index++));
-
         QString colorstr = QString::fromUtf8((const char *) sqlite3_column_text(stmt1, index++));
         if (!colorstr.isEmpty()) {
             incidence->setColor(colorstr);
         }
+
+        index++; // extra2
+        index++; // extra3
+        incidence->setThisAndFuture(sqlite3_column_int(stmt1, index++));
 //    kDebug() << "loaded component for incidence" << incidence->uid() << "notebook" << notebook;
 
         if (!d->selectCustomproperties(incidence, rowid)) {

--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -198,19 +198,13 @@ private:
  /* kDebug() << "SQL query:" << query;    */                  \
   rv = sqlite3_exec( (db), query, NULL, 0, &errmsg );         \
   if ( rv ) {                                                 \
-    if ( rv != SQLITE_CONSTRAINT ) {                          \
-      qCWarning(lcMkcal) << "sqlite3_exec error code:" << rv;           \
-    }                                                         \
-    if ( errmsg ) {                                           \
-      if ( rv != SQLITE_CONSTRAINT ) {                        \
-        qCWarning(lcMkcal) << errmsg;                                   \
+      qCWarning(lcMkcal) << "sqlite3_exec error code:" << rv; \
+      if ( errmsg ) {                                         \
+          qCWarning(lcMkcal) << errmsg;                       \
+          sqlite3_free( errmsg );                             \
+          errmsg = NULL;                                      \
       }                                                       \
-      sqlite3_free( errmsg );                                 \
-      errmsg = NULL;                                          \
-    }                                                         \
-    if ( rv != SQLITE_CONSTRAINT ) {                          \
       goto error;                                             \
-    }                                                         \
   }                                                           \
 }
 
@@ -350,8 +344,6 @@ private:
 #define INDEX_CALENDARPROPERTIES \
 "CREATE INDEX IF NOT EXISTS IDX_CALENDARPROPERTIES on Calendarproperties(CalendarId)"
 
-#define INSERT_TIMEZONES \
-"insert into Timezones values (1, '')"
 #define INSERT_CALENDARS \
 "insert into Calendars values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', '')"
 #define INSERT_COMPONENTS \

--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -193,7 +193,7 @@ private:
 
 }
 
-#define SL3_exec( db )                                        \
+#define SL3_try_exec( db )                                    \
 {                                                             \
  /* kDebug() << "SQL query:" << query;    */                  \
   rv = sqlite3_exec( (db), query, NULL, 0, &errmsg );         \
@@ -204,6 +204,13 @@ private:
           sqlite3_free( errmsg );                             \
           errmsg = NULL;                                      \
       }                                                       \
+  }                                                           \
+}
+
+#define SL3_exec( db )                                        \
+{                                                             \
+  SL3_try_exec( (db) );                                       \
+  if ( rv && rv != SQLITE_CONSTRAINT ) {                      \
       goto error;                                             \
   }                                                           \
 }

--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -307,7 +307,7 @@ private:
 //extra1: used to store the color of a single component.
 
 #define CREATE_COMPONENTS \
-  "CREATE TABLE IF NOT EXISTS Components(ComponentId INTEGER PRIMARY KEY AUTOINCREMENT, Notebook TEXT, Type TEXT, Summary TEXT, Category TEXT, DateStart INTEGER, DateStartLocal INTEGER, StartTimeZone TEXT, HasDueDate INTEGER, DateEndDue INTEGER, DateEndDueLocal INTEGER, EndDueTimeZone TEXT, Duration INTEGER, Classification INTEGER, Location TEXT, Description TEXT, Status INTEGER, GeoLatitude REAL, GeoLongitude REAL, Priority INTEGER, Resources TEXT, DateCreated INTEGER, DateStamp INTEGER, DateLastModified INTEGER, Sequence INTEGER, Comments TEXT, Attachments TEXT, Contact TEXT, InvitationStatus INTEGER, RecurId INTEGER, RecurIdLocal INTEGER, RecurIdTimeZone TEXT, RelatedTo TEXT, URL TEXT, UID TEXT, Transparency INTEGER, LocalOnly INTEGER, Percent INTEGER, DateCompleted INTEGER, DateCompletedLocal INTEGER, CompletedTimeZone TEXT, DateDeleted INTEGER, thisAndFuture INTEGER, extra1 STRING, extra2 STRING, extra3 INTEGER)"
+  "CREATE TABLE IF NOT EXISTS Components(ComponentId INTEGER PRIMARY KEY AUTOINCREMENT, Notebook TEXT, Type TEXT, Summary TEXT, Category TEXT, DateStart INTEGER, DateStartLocal INTEGER, StartTimeZone TEXT, HasDueDate INTEGER, DateEndDue INTEGER, DateEndDueLocal INTEGER, EndDueTimeZone TEXT, Duration INTEGER, Classification INTEGER, Location TEXT, Description TEXT, Status INTEGER, GeoLatitude REAL, GeoLongitude REAL, Priority INTEGER, Resources TEXT, DateCreated INTEGER, DateStamp INTEGER, DateLastModified INTEGER, Sequence INTEGER, Comments TEXT, Attachments TEXT, Contact TEXT, InvitationStatus INTEGER, RecurId INTEGER, RecurIdLocal INTEGER, RecurIdTimeZone TEXT, RelatedTo TEXT, URL TEXT, UID TEXT, Transparency INTEGER, LocalOnly INTEGER, Percent INTEGER, DateCompleted INTEGER, DateCompletedLocal INTEGER, CompletedTimeZone TEXT, DateDeleted INTEGER, extra1 STRING, extra2 STRING, extra3 INTEGER, thisAndFuture INTEGER)"
 
 //Extra fields added for future use in case they are needed. They will be documented here
 //So we can add something without breaking the schema and not adding tables
@@ -355,7 +355,7 @@ private:
 #define INSERT_CALENDARS \
 "insert into Calendars values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', '')"
 #define INSERT_COMPONENTS \
-"insert into Components values (NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, '', 0)"
+"insert into Components values (NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, '', 0, ?)"
 #define INSERT_CUSTOMPROPERTIES \
 "insert into Customproperties values (?, ?, ?, ?)"
 #define INSERT_CALENDARPROPERTIES \
@@ -378,7 +378,7 @@ private:
 #define UPDATE_CALENDARS \
 "update Calendars set Name=?, Description=?, Color=?, Flags=?, syncDate=?, pluginName=?, account=?, attachmentSize=?, modifiedDate=?, sharedWith=?, syncProfile=?, createdDate=? where CalendarId=?"
 #define UPDATE_COMPONENTS \
-"update Components set Notebook=?, Type=?, Summary=?, Category=?, DateStart=?, DateStartLocal=?, StartTimeZone=?, HasDueDate=?, DateEndDue=?, DateEndDueLocal=?, EndDueTimeZone=?, Duration=?, Classification=?, Location=?, Description=?, Status=?, GeoLatitude=?, GeoLongitude=?, Priority=?, Resources=?, DateCreated=?, DateStamp=?, DateLastModified=?, Sequence=?, Comments=?, Attachments=?, Contact=?, RecurId=?, RecurIdLocal=?, RecurIdTimeZone=?, RelatedTo=?, URL=?, UID=?, Transparency=?, LocalOnly=?, Percent=?, DateCompleted=?, DateCompletedLocal=?, CompletedTimeZone=?, thisAndFuture=?, extra1=? where ComponentId=?"
+"update Components set Notebook=?, Type=?, Summary=?, Category=?, DateStart=?, DateStartLocal=?, StartTimeZone=?, HasDueDate=?, DateEndDue=?, DateEndDueLocal=?, EndDueTimeZone=?, Duration=?, Classification=?, Location=?, Description=?, Status=?, GeoLatitude=?, GeoLongitude=?, Priority=?, Resources=?, DateCreated=?, DateStamp=?, DateLastModified=?, Sequence=?, Comments=?, Attachments=?, Contact=?, RecurId=?, RecurIdLocal=?, RecurIdTimeZone=?, RelatedTo=?, URL=?, UID=?, Transparency=?, LocalOnly=?, Percent=?, DateCompleted=?, DateCompletedLocal=?, CompletedTimeZone=?, extra1=?, thisAndFuture=? where ComponentId=?"
 #define UPDATE_COMPONENTS_AS_DELETED \
 "update Components set DateDeleted=? where ComponentId=?"
 //"update Components set DateDeleted=strftime('%s','now') where ComponentId=?"

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -311,8 +311,8 @@ bool SqliteStorage::open()
         goto error;
     }
 
-    if (notebooks().isEmpty()) {
-        qCDebug(lcMkcal) << "Storage is empty, initializing";
+    if (notebooks().isEmpty() || !defaultNotebook()) {
+        qCDebug(lcMkcal) << "Storage has no default notebook, adding one";
         Notebook::Ptr defaultNb(new Notebook(QString::fromLatin1("Default"),
                                              QString(),
                                              QString::fromLatin1("#0000FF")));

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -63,8 +63,6 @@ static const char *createStatements[] =
 {
     CREATE_METADATA,
     CREATE_TIMEZONES,
-    // Create a global empty entry.
-    INSERT_TIMEZONES,
     CREATE_CALENDARS,
     CREATE_COMPONENTS,
     CREATE_RDATES,


### PR DESCRIPTION
It's a follow-up of the discussion from #43 .

Trying to make the migration to version with thisAndFuture column, I found that the initial implementation of the thisAndFuture column was wrong. It created different table schema for migrated DB and new DB, thus the INSERT, the UPDATE and the SELECT were wrong, or let say working only in one case... This should be fixed with the first commit, creating the new column always at the end for migrated or new DBs.

Then, as discussed in #43, I try to make the migration steps as atomic as possible, making the write immediate and setting the pragma there, immediately after the DB changes. This is the third commit.

The second commit is a minor simplification when I noticed that the `SL3_exec` macro was filtering out the constraint errors for the sole purpose of inserting at each opening an existing empty timezone.

When I tested, I noticed that if you delete the default notebook, then the DB has no default notebook anymore (even if it still contains various other notebooks) and this breaks a lot of assertions in the tests. I think it's not a big deal to always create a default notebook on opening. On device, there is already a default notebook (the "private" one), so it should not create additional notebooks.

I tested these changes with an old user_version = 0 DB and with a DB created on the fly by the tests. @pvuorela tell me what do you think about these changes.