### PR TITLE
[mkcal] Bump version in CMakeList so the .pc file is up-to-date.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(mkcal
-	VERSION 0.6.10
+	VERSION 0.7.4
 	DESCRIPTION "Mkcal calendar library")
 
 set(CMAKE_AUTOMOC ON)

--- a/rpm/mkcal-qt5.spec
+++ b/rpm/mkcal-qt5.spec
@@ -1,7 +1,7 @@
 Name:       mkcal-qt5
 
 Summary:    SQlite storage backend for KCalendarCore
-Version:    0.7.2
+Version:    0.7.4
 Release:    1
 License:    LGPLv2+
 URL:        https://github.com/sailfishos/mkcal


### PR DESCRIPTION
Otherwise the .pc file is still generated with 0.6.10 as a version and later tests on version in nemo-qml-plugin-calendar for instance are failing…

@pvuorela, if you may review this, please. Thank you.