### PR TITLE
Always load exceptions when loading a recurring event

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(mkcal
-	VERSION 0.7.4
+	VERSION 0.7.6
 	DESCRIPTION "Mkcal calendar library")
 
 set(CMAKE_AUTOMOC ON)

--- a/rpm/mkcal-qt5.spec
+++ b/rpm/mkcal-qt5.spec
@@ -1,7 +1,7 @@
 Name:       mkcal-qt5
 
 Summary:    SQlite storage backend for KCalendarCore
-Version:    0.7.4
+Version:    0.7.6
 Release:    1
 License:    LGPLv2+
 URL:        https://github.com/sailfishos/mkcal

--- a/src/dummystorage.h
+++ b/src/dummystorage.h
@@ -100,7 +100,7 @@ public:
     {
         return true;
     }
-    bool load(const QString &, const QDateTime &)
+    bool load(const QString &)
     {
         return true;
     }
@@ -109,10 +109,6 @@ public:
         return true;
     }
     bool load(const QDate &, const QDate &)
-    {
-        return true;
-    }
-    bool loadSeries(const QString &)
     {
         return true;
     }

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -332,6 +332,20 @@ void ExtendedStorage::setIsGeoCreatedLoaded(bool loaded)
     d->mIsGeoCreatedLoaded = loaded;
 }
 
+bool ExtendedStorage::loadSeries(const QString &uid)
+{
+    qCWarning(lcMkcal) << "deprecated call to loadSeries(), use load() instead.";
+    return load(uid);
+}
+
+bool ExtendedStorage::load(const QString &uid, const QDateTime &recurrenceId)
+{
+    Q_UNUSED(recurrenceId);
+
+    qCWarning(lcMkcal) << "deprecated call to load(uid, recid), use load(uid) instead.";
+    return load(uid);
+}
+
 void ExtendedStorageObserver::storageModified(ExtendedStorage *storage,
                                               const QString &info)
 {

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -122,13 +122,38 @@ public:
     virtual bool load() = 0;
 
     /**
-      Load incidence by uid into the memory.
+      Load all incidences sharing the same uid into the memory.
 
-      @param uid is uid of incidence
-      @param recurrenceid is recurrenceid of incidence, default null
+      @param uid is uid of the series
       @return true if the load was successful; false otherwise.
     */
-    virtual bool load(const QString &uid, const QDateTime &recurrenceId = QDateTime()) = 0;
+    virtual bool load(const QString &uid) = 0;
+
+    /**
+      Load all incidences sharing the same uid into the memory.
+
+      Deprecated call, equivalent to calling load(const QString &uid).
+
+      @param uid is uid of the series
+      @return true if the load was successful; false otherwise.
+    */
+    bool loadSeries(const QString &uid);
+
+    /**
+      Load incidence by uid/recid into the memory.
+
+      This method is deprecated since it may populate calendars
+      with orphaned exceptions, or recurring event without
+      their exceptions.
+
+      Use load(const QString &uid) which ensures for
+      recurring incidences to also get their exceptions.
+
+      @param uid is uid of incidence
+      @param recurrenceid is recurrenceid of incidence
+      @return true if the load was successful; false otherwise.
+    */
+    bool load(const QString &uid, const QDateTime &recurrenceId);
 
     /**
       Load incidences at given date into the memory. All incidences that
@@ -155,14 +180,6 @@ public:
       @return true if the load was successful; false otherwise.
     */
     virtual bool load(const QDate &start, const QDate &end) = 0;
-
-    /**
-      Load all incidences sharing the same uid into the memory.
-
-      @param uid is uid of the series
-      @return true if the load was successful; false otherwise.
-    */
-    virtual bool loadSeries(const QString &uid) = 0;
 
     /**
       Load the incidence matching the given identifier. This method may be

--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -435,8 +435,6 @@ private:
 "select * from Components where (DateEndDue>=? or (DateEndDue=0 and DateStart>=?)) and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_DATE_END \
 "select * from Components where DateStart<? and DateDeleted=0"
-#define SELECT_COMPONENTS_BY_UID_AND_RECURID \
-"select * from Components where UID=? and RecurId=? and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_UID \
 "select * from Components where UID=? and DateDeleted=0"
 #define SELECT_COMPONENTS_BY_NOTEBOOKUID \

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -139,6 +139,7 @@ public:
 
     bool addIncidence(const Incidence::Ptr &incidence, const QString &notebookUid);
     int loadIncidences(sqlite3_stmt *stmt1,
+                       bool loadRecurringIncidences = false,
                        int limit = -1, QDateTime *last = NULL, bool useDate = false,
                        bool ignoreEnd = false);
     bool saveIncidences(QHash<QString, Incidence::Ptr> &list, DBOperation dbop,
@@ -655,7 +656,7 @@ bool SqliteStorage::loadGeoIncidences()
 
     SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
-    count = d->loadIncidences(stmt1);
+    count = d->loadIncidences(stmt1, true);
 
 error:
     d->mIsLoading = false;
@@ -689,7 +690,7 @@ bool SqliteStorage::loadGeoIncidences(float geoLatitude, float geoLongitude,
     SL3_bind_int64(stmt1, index, geoLatitude + diffLatitude);
     SL3_bind_int64(stmt1, index, geoLongitude + diffLongitude);
 
-    count = d->loadIncidences(stmt1);
+    count = d->loadIncidences(stmt1, true);
 
 error:
     d->mIsLoading = false;
@@ -717,7 +718,7 @@ bool SqliteStorage::loadAttendeeIncidences()
 
     SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
-    count = d->loadIncidences(stmt1);
+    count = d->loadIncidences(stmt1, true);
 
 error:
     d->mIsLoading = false;
@@ -749,7 +750,7 @@ int SqliteStorage::loadUncompletedTodos()
 
     SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
 
-    count = d->loadIncidences(stmt1);
+    count = d->loadIncidences(stmt1, true);
 
     setIsUncompletedTodosLoaded(count >= 0);
 
@@ -801,7 +802,7 @@ int SqliteStorage::loadCompletedTodos(bool hasDate, int limit, QDateTime *last)
     SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     SL3_bind_int64(stmt1, index, secsStart);
 
-    count = d->loadIncidences(stmt1, limit, last, hasDate);
+    count = d->loadIncidences(stmt1, true, limit, last, hasDate);
 
     if (count >= 0 && count < limit) {
         if (hasDate) {
@@ -846,7 +847,7 @@ int SqliteStorage::loadJournals(int limit, QDateTime *last)
     SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     SL3_bind_int64(stmt1, index, secsStart);
 
-    count = d->loadIncidences(stmt1, limit, last, true);
+    count = d->loadIncidences(stmt1, true, limit, last, true);
 
     if (count >= 0 && count < limit) {
         setIsJournalsLoaded(true);
@@ -898,7 +899,7 @@ int SqliteStorage::loadIncidences(bool hasDate, int limit, QDateTime *last)
     SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     SL3_bind_int64(stmt1, index, secsStart);
 
-    count = d->loadIncidences(stmt1, limit, last, hasDate);
+    count = d->loadIncidences(stmt1, true, limit, last, hasDate);
 
     if (count >= 0 && count < limit) {
         if (hasDate) {
@@ -946,7 +947,7 @@ int SqliteStorage::loadFutureIncidences(int limit, QDateTime *last)
     SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     SL3_bind_int64(stmt1, index, secsStart);
 
-    count = d->loadIncidences(stmt1, limit, last, true, true);
+    count = d->loadIncidences(stmt1, true, limit, last, true, true);
 
     if (count >= 0 && count < limit) {
         setIsFutureDateLoaded(true);
@@ -999,7 +1000,7 @@ int SqliteStorage::loadGeoIncidences(bool hasDate, int limit, QDateTime *last)
     SL3_prepare_v2(d->mDatabase, query1, qsize1, &stmt1, NULL);
     SL3_bind_int64(stmt1, index, secsStart);
 
-    count = d->loadIncidences(stmt1, limit, last, hasDate);
+    count = d->loadIncidences(stmt1, true, limit, last, hasDate);
 
     if (count >= 0 && count < limit) {
         if (hasDate) {
@@ -1066,7 +1067,7 @@ int SqliteStorage::loadContactIncidences(const Person &person, int limit, QDateT
     }
     SL3_bind_int64(stmt1, index, secsStart);
 
-    count = d->loadIncidences(stmt1, limit, last, false);
+    count = d->loadIncidences(stmt1, true, limit, last, false);
 
 error:
     d->mIsLoading = false;
@@ -1126,6 +1127,7 @@ bool SqliteStorage::Private::addIncidence(const Incidence::Ptr &incidence, const
 }
 
 int SqliteStorage::Private::loadIncidences(sqlite3_stmt *stmt1,
+                                           bool loadRecurringIncidences,
                                            int limit, QDateTime *last,
                                            bool useDate,
                                            bool ignoreEnd)
@@ -1134,6 +1136,7 @@ int SqliteStorage::Private::loadIncidences(sqlite3_stmt *stmt1,
     Incidence::Ptr incidence;
     QDateTime previous, date;
     QString notebookUid;
+    QSet<QString> recurringUids;
 
     if (!mSem.acquire()) {
         qCWarning(lcMkcal) << "cannot lock" << mDatabaseName << "error" << mSem.errorString();
@@ -1166,6 +1169,10 @@ int SqliteStorage::Private::loadIncidences(sqlite3_stmt *stmt1,
             // qCDebug(lcMkcal) << "updating incidence" << incidence->uid()
             //                  << incidence->dtStart() << endDateTime
             //                  << "in calendar";
+            if (loadRecurringIncidences
+                && (incidence->recurs() || incidence->hasRecurrenceId())) {
+                recurringUids.insert(incidence->uid());
+            }
             count += 1;
         }
     }
@@ -1174,6 +1181,31 @@ int SqliteStorage::Private::loadIncidences(sqlite3_stmt *stmt1,
     }
 
     sqlite3_finalize(stmt1);
+
+    if (recurringUids.count() > 0) {
+        // Additionally load any exception or parent to ensure calendar
+        // consistency.
+        int rv = 0;
+        sqlite3_stmt *loadByUid = NULL;
+        const char *query1 = NULL;
+        int qsize1 = 0;
+        query1 = SELECT_COMPONENTS_BY_UID;
+        qsize1 = sizeof(SELECT_COMPONENTS_BY_UID);
+        SL3_prepare_v2(mDatabase, query1, qsize1, &loadByUid, NULL);
+
+        for (const QString &uid : const_cast<const QSet<QString>&>(recurringUids)) {
+            int index = 1;
+            QByteArray u = uid.toUtf8();
+            SL3_reset(loadByUid);
+            SL3_bind_text(loadByUid, index, u.constData(), u.length(), SQLITE_STATIC);
+            while ((incidence = mFormat->selectComponents(stmt1, notebookUid))) {
+                addIncidence(incidence, notebookUid);
+            }
+        }
+
+    error:
+        sqlite3_finalize(loadByUid);
+    }
 
     if (!mSem.release()) {
         qCWarning(lcMkcal) << "cannot release lock" << mDatabaseName << "error" << mSem.errorString();

--- a/src/sqlitestorage.h
+++ b/src/sqlitestorage.h
@@ -105,9 +105,9 @@ public:
 
     /**
       @copydoc
-      ExtendedStorage::load(const QString &, const QDateTime &)
+      ExtendedStorage::load(const QString &)
     */
-    bool load(const QString &uid, const QDateTime &recurrenceId = QDateTime());
+    bool load(const QString &uid);
 
     /**
       @copydoc
@@ -120,12 +120,6 @@ public:
       ExtendedStorage::load(const QDate &, const QDate &)
     */
     bool load(const QDate &start, const QDate &end);
-
-    /**
-      @copydoc
-      ExtendedStorage::loadSeries(const QString &)
-    */
-    bool loadSeries(const QString &uid);
 
     /**
       @copydoc

--- a/tests/tst_load.cpp
+++ b/tests/tst_load.cpp
@@ -129,15 +129,17 @@ void tst_load::testById()
 
     QVERIFY(calendar->events().isEmpty());
 
-    QVERIFY(storage->load(occurrence->uid(), occurrence->recurrenceId()));
-    QCOMPARE(calendar->events().length(), 1);
+    QVERIFY(storage->load(occurrence->uid()));
+    QCOMPARE(calendar->events().length(), 2);
     occurrence = calendar->event(occurrence->uid(),
                                  occurrence->recurrenceId());
     QVERIFY(occurrence);
     QVERIFY(calendar->deleteIncidence(occurrence));
-    QVERIFY(calendar->events().isEmpty());
-    QVERIFY(storage->load(occurrence->uid(), occurrence->recurrenceId()));
-    QVERIFY(calendar->events().isEmpty());
+    QCOMPARE(calendar->events().length(), 1);
+    QVERIFY(!calendar->incidence(occurrence->uid(), occurrence->recurrenceId()));
+    QVERIFY(storage->load(occurrence->uid()));
+    QCOMPARE(calendar->events().length(), 1);
+    QVERIFY(!calendar->incidence(occurrence->uid(), occurrence->recurrenceId()));
 
     QVERIFY(storage->load(event->uid()));
     QCOMPARE(calendar->events().length(), 1);
@@ -178,12 +180,12 @@ void tst_load::testSeries()
 
     QVERIFY(calendar->events().isEmpty());
 
-    QVERIFY(storage->loadSeries(event->uid()));
+    QVERIFY(storage->load(event->uid()));
     QCOMPARE(calendar->events().length(), 2);
     QVERIFY(calendar->incidence(event->uid()));
     QVERIFY(calendar->incidence(occurrence->uid(), occurrence->recurrenceId()));
 
-    QVERIFY(storage->loadSeries(single->uid()));
+    QVERIFY(storage->load(single->uid()));
     QCOMPARE(calendar->events().length(), 3);
     QVERIFY(calendar->incidence(single->uid()));
 

--- a/tests/tst_load.cpp
+++ b/tests/tst_load.cpp
@@ -39,6 +39,7 @@ private slots:
     void testSeries();
     void testByInstanceIdentifier();
     void testByDate();
+    void testByAttendee();
     void testRange();
     void testRange_data();
 
@@ -304,6 +305,33 @@ void tst_load::testByDate()
     QVERIFY(mStorage->calendar()->deleteIncidence(event4));
     QVERIFY(mStorage->calendar()->deleteIncidence(event3));
     QVERIFY(mStorage->calendar()->deleteIncidence(event2));
+    QVERIFY(mStorage->calendar()->deleteIncidence(event));
+    QVERIFY(mStorage->save(ExtendedStorage::PurgeDeleted));
+}
+
+void tst_load::testByAttendee()
+{
+    KCalendarCore::Event::Ptr event(new KCalendarCore::Event);
+    event->setDtStart(QDateTime(QDate(2023,2,2), QTime(15, 35), Qt::UTC));
+    event->addAttendee(KCalendarCore::Attendee(QString::fromLatin1("Alice"),
+                                               QString::fromLatin1("alice@example.org")));
+    event->recurrence()->setDaily(1);
+    QVERIFY(mStorage->calendar()->addEvent(event));
+    KCalendarCore::Incidence::Ptr exception = KCalendarCore::Calendar::createException(event, event->dtStart().addDays(2));
+    exception->clearAttendees();
+    QVERIFY(mStorage->calendar()->addIncidence(exception));
+    QVERIFY(mStorage->save());
+
+    ExtendedCalendar::Ptr calendar(new ExtendedCalendar(QTimeZone::utc()));
+    ExtendedStorage::Ptr storage = ExtendedCalendar::defaultStorage(calendar);
+    QVERIFY(storage->open());
+
+    QVERIFY(calendar->events().isEmpty());
+
+    QVERIFY(storage->loadAttendeeIncidences());
+    QVERIFY(calendar->incidence(event->uid()));
+    QVERIFY(calendar->incidence(exception->uid(), exception->recurrenceId()));
+
     QVERIFY(mStorage->calendar()->deleteIncidence(event));
     QVERIFY(mStorage->save(ExtendedStorage::PurgeDeleted));
 }

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -1296,6 +1296,20 @@ void tst_storage::tst_deleted()
     event3->setSummary("Re-created event");
     event3->setCreated(QDateTime::currentDateTimeUtc().addSecs(-3));
 
+    KCalendarCore::Event::Ptr event4(new KCalendarCore::Event);
+    event4->setDtStart(QDateTime(QDate(2022, 12, 6), QTime(13, 42)));
+    event4->setSummary("Recurring event wth exceptions");
+    event4->setCreated(QDateTime::currentDateTimeUtc().addSecs(-3));
+    event4->recurrence()->setDaily(1);
+    KCalendarCore::Event::Ptr event41(event4->clone());
+    event41->clearRecurrence();
+    event41->setRecurrenceId(event4->dtStart().addDays(2));
+    event41->setSummary("Exception 1");
+    KCalendarCore::Event::Ptr event42(event4->clone());
+    event42->clearRecurrence();
+    event42->setRecurrenceId(event4->dtStart().addDays(3));
+    event42->setSummary("Exception 2");
+
     QVERIFY(m_calendar->addEvent(event, notebook->uid()));
     QVERIFY(m_calendar->addEvent(event2, notebook->uid()));
     QVERIFY(m_calendar->addEvent(event3, notebook->uid()));
@@ -1360,6 +1374,44 @@ void tst_storage::tst_deleted()
     QVERIFY(m_storage->loadNotebookIncidences(notebook->uid()));
     fetchEvent3 = m_calendar->event(event3->uid());
     QVERIFY(fetchEvent3);
+    deleted.clear();
+    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(-2), notebook->uid()));
+    QCOMPARE(deleted.length(), 0);
+
+    // Marking as deleted a recurring event marks the exceptions also,
+    // even if they are not explicitely loaded
+    QVERIFY(m_calendar->addEvent(event4, notebook->uid()));
+    QVERIFY(m_calendar->addEvent(event41, notebook->uid()));
+    QVERIFY(m_calendar->addEvent(event42, notebook->uid()));
+    QVERIFY(m_storage->save());
+    reloadDb();
+    QVERIFY(m_storage->load(event4->uid()));
+    KCalendarCore::Event::Ptr fetchEvent4 = m_calendar->event(event4->uid());
+    QVERIFY(fetchEvent4);
+    QVERIFY(m_calendar->deleteIncidence(fetchEvent4));
+    QVERIFY(m_storage->save());
+    reloadDb();
+    deleted.clear();
+    QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(-2), notebook->uid()));
+    QCOMPARE(deleted.length(), 3);
+
+    // Deleting a recurring event also wipes out the exceptions,
+    // even if they are not explicitely loaded
+    QVERIFY(m_calendar->addEvent(event4, notebook->uid()));
+    QVERIFY(m_calendar->addEvent(event41, notebook->uid()));
+    QVERIFY(m_calendar->addEvent(event42, notebook->uid()));
+    QVERIFY(m_storage->save());
+    reloadDb();
+    QVERIFY(m_storage->load(event4->uid()));
+    fetchEvent4 = m_calendar->event(event4->uid());
+    QVERIFY(fetchEvent4);
+    QVERIFY(m_calendar->deleteIncidence(fetchEvent4));
+    QVERIFY(m_storage->save(ExtendedStorage::PurgeDeleted));
+    reloadDb();
+    QVERIFY(m_storage->loadNotebookIncidences(notebook->uid()));
+    QVERIFY(!m_calendar->event(event4->uid()));
+    QVERIFY(!m_calendar->event(event41->uid(), event41->recurrenceId()));
+    QVERIFY(!m_calendar->event(event42->uid(), event42->recurrenceId()));
     deleted.clear();
     QVERIFY(m_storage->deletedIncidences(&deleted, QDateTime::currentDateTimeUtc().addSecs(-2), notebook->uid()));
     QCOMPARE(deleted.length(), 0);
@@ -2158,20 +2210,31 @@ void tst_storage::tst_storageObserver()
     QVERIFY(!modified.wait(200)); // Even after 200ms the modified signal is not emitted.
 
     KCalendarCore::Event::Ptr event(new KCalendarCore::Event);
+    event->setDtStart(QDateTime(QDate(2023, 1, 13), QTime(16, 35)));
+    event->recurrence()->setDaily(2);
     QVERIFY(m_calendar->addIncidence(event));
+    KCalendarCore::Incidence::Ptr exception = m_calendar->createException(event, event->dtStart().addDays(4));
+    QVERIFY(m_calendar->addIncidence(exception));
     QVERIFY(updated.isEmpty());
     m_storage->save();
     QCOMPARE(updated.count(), 1);
     args = updated.takeFirst();
     QCOMPARE(args.count(), 3);
-    QCOMPARE(args[0].value<KCalendarCore::Incidence::List>().count(), 1);
-    QCOMPARE(args[0].value<KCalendarCore::Incidence::List>()[0].staticCast<KCalendarCore::Event>(), event);
+    KCalendarCore::Incidence::List added = args[0].value<KCalendarCore::Incidence::List>();
+    QCOMPARE(added.count(), 2);
+    if (added[0]->recurs()) {
+        QCOMPARE(added[0].staticCast<KCalendarCore::Event>(), event);
+        QCOMPARE(added[1].staticCast<KCalendarCore::Event>(), exception.staticCast<KCalendarCore::Event>());
+    } else {
+        QCOMPARE(added[1].staticCast<KCalendarCore::Event>(), event);
+        QCOMPARE(added[0].staticCast<KCalendarCore::Event>(), exception.staticCast<KCalendarCore::Event>());
+    }
     QVERIFY(args[1].value<KCalendarCore::Incidence::List>().isEmpty());
     QVERIFY(args[2].value<KCalendarCore::Incidence::List>().isEmpty());
     QVERIFY(modified.isEmpty());
     QVERIFY(!modified.wait(200));
 
-    event->setDtStart(QDateTime::currentDateTime());
+    event->setDtEnd(event->dtStart().addSecs(3600));
     QVERIFY(updated.isEmpty());
     m_storage->save();
     QCOMPARE(updated.count(), 1);
@@ -2192,8 +2255,10 @@ void tst_storage::tst_storageObserver()
     QCOMPARE(args.count(), 3);
     QVERIFY(args[0].value<KCalendarCore::Incidence::List>().isEmpty());
     QVERIFY(args[1].value<KCalendarCore::Incidence::List>().isEmpty());
-    QCOMPARE(args[2].value<KCalendarCore::Incidence::List>().count(), 1);
-    QCOMPARE(args[2].value<KCalendarCore::Incidence::List>()[0].staticCast<KCalendarCore::Event>(), event);
+    KCalendarCore::Incidence::List deleted = args[2].value<KCalendarCore::Incidence::List>();
+    QCOMPARE(deleted.count(), 2);
+    QCOMPARE(deleted[0].staticCast<KCalendarCore::Event>(), event);
+    QCOMPARE(deleted[1].staticCast<KCalendarCore::Event>(), exception.staticCast<KCalendarCore::Event>());
     QVERIFY(modified.isEmpty());
     QVERIFY(!modified.wait(200));
 


### PR DESCRIPTION
@pvuorela, following your advice in #40, I'm proposing this PR where I've deprecated `loadSeries()` and changed the `load()` implementation to act as `loadSeries()`. In addition, I've pushed a commit that always load exceptions (or parents) when using methods that may load one without the other. For instance, if you have attendees in your recurring events, and you setup an exception without attendees, calling `loadByAttendees()` will also load the exception now, ensuring the complete consistency of the event. Of course, it's just database loading, it's then up to the UI not to show the exception in that case.

If this approach is better than the one in #40, I'll close it.