### PR TITLE
[mkcal] Add a search method.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(mkcal
-	VERSION 0.7.6
+	VERSION 0.7.14
 	DESCRIPTION "Mkcal calendar library")
 
 set(CMAKE_AUTOMOC ON)

--- a/rpm/mkcal-qt5.spec
+++ b/rpm/mkcal-qt5.spec
@@ -1,7 +1,7 @@
 Name:       mkcal-qt5
 
 Summary:    SQlite storage backend for KCalendarCore
-Version:    0.7.6
+Version:    0.7.14
 Release:    1
 License:    LGPLv2+
 URL:        https://github.com/sailfishos/mkcal

--- a/src/dummystorage.h
+++ b/src/dummystorage.h
@@ -113,6 +113,10 @@ public:
     {
         return true;
     }
+    bool search(const QString &, QStringList *, int)
+    {
+        return true;
+    }
     bool loadNotebooks()
     {
         return true;

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -309,6 +309,23 @@ public:
                                const QString &notebookUid = QString()) = 0;
 
     /**
+      Get all incidences from storage that match key. Incidences are
+      loaded into the associated ExtendedCalendar. More incidences than
+      the listed ones in @param identifiers may be loaded into memory
+      to ensure calendar consistency with respect to exceptions of
+      recurring incidences.
+
+      Matching is done on summary, description and location fields.
+
+      @param key can be any substring from the summary, the description or the location.
+      @param identifiers optional, stores the instance identifiers of
+             matching incidences.
+      @param limit the maximum number of loaded incidences, unlimited by default
+      @return true on success.
+     */
+    virtual bool search(const QString &key, QStringList *identifiers, int limit = 0) = 0;
+
+    /**
       Get deletion time of incidence
 
       @param incidence incidence to check

--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -452,6 +452,9 @@ private:
 #define SELECT_COMPONENTS_BY_UID_RECID_AND_DELETED \
 "select ComponentId, DateDeleted from Components where UID=? and RecurId=? and DateDeleted<>0"
 
+#define SEARCH_COMPONENTS \
+"select * from Components where summary like ? escape '\\' or description like ? escape '\\' or location like ? escape '\\' order by datestart desc"
+
 #define UNSET_FLAG_FROM_CALENDAR \
 "update Calendars set Flags=(Flags & (~?))"
 

--- a/src/sqlitestorage.h
+++ b/src/sqlitestorage.h
@@ -211,6 +211,12 @@ public:
 
     /**
       @copydoc
+      ExtendedStorage::search()
+    */
+    bool search(const QString &key, QStringList *identifiers, int limit = 0);
+
+    /**
+      @copydoc
       ExtendedStorage::incidenceDeletedDate()
     */
     QDateTime incidenceDeletedDate(const KCalendarCore::Incidence::Ptr &incidence);


### PR DESCRIPTION
This new method is loading incidences
matching a string pattern in summary, description
or location. Incidences are added to the calendar
and the list of matching instance identifiers is
return to avoid searching in the calendar for match in client code.

@pvuorela, to add search capability to the calendar application, there are two possibilities : either we load all incidences and then search inside the memory calendar for matching incidences, or we delegate the search function to the database and load only matching incidences. The first one does not scale well for large number of incidences. So I went for the second option. But doing so, one needs to know what the database has loaded, to avoid searching again later in the memory calendar. But such information of loaded incidences does not exist at the moment for existing loading routines.

It exists some functions though like `insertedIncidences()` that poke the database and return in a separated list, matching incidences. So I may have added the search routine with an API such as the one of `insertedIncidences()`. But this has the issue that the notebook information is lost in such API (you don't know to which notebook returned incidences belong to), and anyway, the incidences will have to be loaded in the calendar to display the results.

That's why I choose this hybrid API for the search routine : it is a loading routine, but it also returns the list of loaded incidences (as instance identifiers to be thread safe, in case we will go between thread boundaries since Incidence::List is not thread safe).