### PR TITLE
[mkcal] Remove ExtendedCalendar::rawJournals(). JB#60291

### DIFF
--- a/src/extendedcalendar.cpp
+++ b/src/extendedcalendar.cpp
@@ -258,67 +258,6 @@ bool ExtendedCalendar::addJournal(const Journal::Ptr &aJournal, const QString &n
     }
 }
 
-Journal::List ExtendedCalendar::rawJournals(const QDate &start, const QDate &end,
-                                            const QTimeZone &timeZone, bool inclusive) const
-{
-    Q_UNUSED(inclusive);
-    Journal::List journalList;
-    const QTimeZone &tz = timeZone.isValid() ? timeZone : this->timeZone();
-    QDateTime st(start, QTime(0, 0, 0), tz);
-    QDateTime nd(end, QTime(23, 59, 999), tz);
-
-    // Get journals
-    const Journal::List journals(rawJournals());
-    for (const Journal::Ptr &journal: journals) {
-        if (!isVisible(journal)) {
-            continue;
-        }
-        QDateTime rStart = journal->dtStart();
-        if (nd.isValid() && nd < rStart) {
-            continue;
-        }
-        if (inclusive && st.isValid() && rStart < st) {
-            continue;
-        }
-
-        if (!journal->recurs()) {   // non-recurring journals
-            // TODO_ALVARO: journals don't have endDt, bug?
-            QDateTime rEnd = journal->dateTime(Incidence::RoleEnd);
-            if (st.isValid() && rEnd < st) {
-                continue;
-            }
-            if (inclusive && nd.isValid() && nd < rEnd) {
-                continue;
-            }
-        } else { // recurring journals
-            switch (journal->recurrence()->duration()) {
-            case -1: // infinite
-                if (inclusive) {
-                    continue;
-                }
-                break;
-            case 0: // end date given
-            default: // count given
-                QDateTime rEnd(journal->recurrence()->endDate(), QTime(23, 59, 999), tz);
-                if (!rEnd.isValid()) {
-                    continue;
-                }
-                if (st.isValid() && rEnd < st) {
-                    continue;
-                }
-                if (inclusive && nd.isValid() && nd < rEnd) {
-                    continue;
-                }
-                break;
-            } // switch(duration)
-        } //if(recurs)
-
-        journalList.append(journal);
-    }
-
-    return journalList;
-}
-
 void ExtendedCalendar::deleteAllIncidences()
 {
     const Event::List events = rawEvents();

--- a/src/extendedcalendar.h
+++ b/src/extendedcalendar.h
@@ -336,26 +336,6 @@ public:
     */
     bool addJournal(const KCalendarCore::Journal::Ptr &journal, const QString &notebookUid);
 
-    using KCalendarCore::Calendar::rawJournals;
-
-    /**
-      Returns an unfiltered list of all Journals occurring within a date range.
-
-      @param start is the starting date
-      @param end is the ending date
-      @param timespec time zone etc. to interpret @p start and @p end,
-                      or the calendar's default time spec if none is specified
-      @param inclusive if true only Journals which are completely included
-      within the date range are returned.
-
-      @return the list of unfiltered Journals occurring within the specified
-      date range.
-    */
-    KCalendarCore::Journal::List rawJournals(
-        const QDate &start, const QDate &end,
-        const QTimeZone &timespec = QTimeZone(),
-        bool inclusive = false) const;
-
     using KCalendarCore::Calendar::journals;
 
     /**


### PR DESCRIPTION
Nothing should be needing this, the whole journal support is pretty much unused/untested, and the similar rawEvents() method was removed long time ago already.

Let's just get rid of this one too.

@dcaliste 