### PR TITLE
[mkcal] Remove timezone from database storage.

### DIFF
--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -39,8 +39,6 @@
 
 #include <sqlite3.h>
 
-#include <QTimeZone>
-
 namespace mKCal {
 
 /**
@@ -94,7 +92,7 @@ public:
     /**
       Constructor a new Sqlite Format object.
     */
-    SqliteFormat(sqlite3 *database, const QTimeZone &timeZone = {});
+    SqliteFormat(sqlite3 *database);
 
     /**
       Destructor.
@@ -154,7 +152,7 @@ public:
       @param dt datetime
       @return seconds relative to origin
     */
-    sqlite3_int64 toOriginTime(const QDateTime &dt);
+    static sqlite3_int64 toOriginTime(const QDateTime &dt);
 
     /**
       Convert local datetime to seconds relative to the origin.
@@ -162,21 +160,21 @@ public:
       @param dt datetime
       @return seconds relative to origin
     */
-    sqlite3_int64 toLocalOriginTime(const QDateTime &dt);
+    static sqlite3_int64 toLocalOriginTime(const QDateTime &dt);
 
     /**
       Convert seconds from the origin to clock time.
       @param seconds relative to origin.
       @return clocktime datetime.
     */
-    QDateTime fromLocalOriginTime(sqlite3_int64 seconds);
+    static QDateTime fromLocalOriginTime(sqlite3_int64 seconds);
 
     /**
       Convert seconds from the origin to UTC datetime.
       @param seconds relative to origin.
       @return UTC datetime.
     */
-    QDateTime fromOriginTime(sqlite3_int64 seconds);
+    static QDateTime fromOriginTime(sqlite3_int64 seconds);
 
     /**
       Convert seconds from the origin to datetime in given timezone.
@@ -184,7 +182,7 @@ public:
       @param zonename timezone name.
       @return datetime in timezone.
     */
-    QDateTime fromOriginTime(sqlite3_int64 seconds, const QByteArray &zonename);
+    static QDateTime fromOriginTime(sqlite3_int64 seconds, const QByteArray &zonename);
 
 private:
     //@cond PRIVATE
@@ -301,8 +299,6 @@ private:
 
 #define CREATE_METADATA \
   "CREATE TABLE IF NOT EXISTS Metadata(transactionId INTEGER)"
-#define CREATE_TIMEZONES \
-  "CREATE TABLE IF NOT EXISTS Timezones(TzId INTEGER PRIMARY KEY, ICalData TEXT)"
 #define CREATE_CALENDARS \
   "CREATE TABLE IF NOT EXISTS Calendars(CalendarId TEXT PRIMARY KEY, Name TEXT, Description TEXT, Color INTEGER, Flags INTEGER, syncDate INTEGER, pluginName TEXT, account TEXT, attachmentSize INTEGER, modifiedDate INTEGER, sharedWith TEXT, syncProfile TEXT, createdDate INTEGER, extra1 STRING, extra2 STRING)"
 
@@ -375,8 +371,6 @@ private:
 
 #define UPDATE_METADATA \
 "replace into Metadata (rowid, transactionId) values (1, ?)"
-#define UPDATE_TIMEZONES \
-"update Timezones set ICalData=? where TzId=1"
 #define UPDATE_CALENDARS \
 "update Calendars set Name=?, Description=?, Color=?, Flags=?, syncDate=?, pluginName=?, account=?, attachmentSize=?, modifiedDate=?, sharedWith=?, syncProfile=?, createdDate=? where CalendarId=?"
 #define UPDATE_COMPONENTS \
@@ -406,8 +400,6 @@ private:
 
 #define SELECT_METADATA \
 "select * from Metadata where rowid=1"
-#define SELECT_TIMEZONES \
-"select * from Timezones where TzId=1"
 #define SELECT_CALENDARS_ALL \
 "select * from Calendars order by Name"
 #define SELECT_COMPONENTS_ALL \

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -516,16 +516,14 @@ void tst_storage::tst_recurrenceExpansion()
 
 void tst_storage::tst_origintimes()
 {
-    SqliteFormat format(nullptr, m_storage->calendar()->timeZone());
-
     QDateTime utcTime(QDate(2014, 1, 15), QTime(), Qt::UTC);
     QDateTime localTime(QDate(2014, 1, 15), QTime(), Qt::LocalTime);
 
     // local origin time is the same as specific time set to utc
     // note: currently origin time of clock time is saved as time in current time zone.
     // that does not necessarily make sense, but better be careful when changing behavior there.
-    QCOMPARE(format.toOriginTime(utcTime), format.toLocalOriginTime(utcTime));
-    QCOMPARE(format.toLocalOriginTime(localTime), format.toLocalOriginTime(utcTime));
+    QCOMPARE(SqliteFormat::toOriginTime(utcTime), SqliteFormat::toLocalOriginTime(utcTime));
+    QCOMPARE(SqliteFormat::toLocalOriginTime(localTime), SqliteFormat::toLocalOriginTime(utcTime));
 }
 
 void tst_storage::tst_rawEvents_data()
@@ -2201,16 +2199,6 @@ void tst_storage::tst_storageObserver()
     TestStorageObserver observer(m_storage);
     QSignalSpy updated(&observer, &TestStorageObserver::updated);
     QSignalSpy modified(&observer, &TestStorageObserver::modified);
-    QVERIFY(updated.isEmpty());
-    m_storage->save();
-    QCOMPARE(updated.count(), 1);
-    QList<QVariant> args = updated.takeFirst();
-    QCOMPARE(args.count(), 3);
-    QVERIFY(args[0].value<KCalendarCore::Incidence::List>().isEmpty());
-    QVERIFY(args[1].value<KCalendarCore::Incidence::List>().isEmpty());
-    QVERIFY(args[2].value<KCalendarCore::Incidence::List>().isEmpty());
-    QVERIFY(modified.isEmpty());
-    QVERIFY(!modified.wait(200)); // Even after 200ms the modified signal is not emitted.
 
     KCalendarCore::Event::Ptr event(new KCalendarCore::Event);
     event->setDtStart(QDateTime(QDate(2023, 1, 13), QTime(16, 35)));
@@ -2221,7 +2209,7 @@ void tst_storage::tst_storageObserver()
     QVERIFY(updated.isEmpty());
     m_storage->save();
     QCOMPARE(updated.count(), 1);
-    args = updated.takeFirst();
+    QList<QVariant> args = updated.takeFirst();
     QCOMPARE(args.count(), 3);
     KCalendarCore::Incidence::List added = args[0].value<KCalendarCore::Incidence::List>();
     QCOMPARE(added.count(), 2);
@@ -2235,7 +2223,7 @@ void tst_storage::tst_storageObserver()
     QVERIFY(args[1].value<KCalendarCore::Incidence::List>().isEmpty());
     QVERIFY(args[2].value<KCalendarCore::Incidence::List>().isEmpty());
     QVERIFY(modified.isEmpty());
-    QVERIFY(!modified.wait(200));
+    QVERIFY(!modified.wait(200)); // Even after 200ms the modified signal is not emitted.
 
     event->setDtEnd(event->dtStart().addSecs(3600));
     QVERIFY(updated.isEmpty());


### PR DESCRIPTION
The storage of timezones to check incidences upon
when the incidence timezone name is not matching
any of the system, is deprecated. KCalendarCore
is not providing anymore a timezone definition when parsing ICS data. It is always using the system
timezone definitions to match any received ICS
data. There is thus no need anymore to store a
timezone defintion in the database.

Not to complexify the code, the existing
timezones table is kept as it is, simply not
used anymore.

@pvuorela , let's try this removal also while at it. Tests are still passing, so far so good. The removed part in the observer test is due to the fact that now save() is not emitting updated() all the time. It was the case before because the timezone path was always used and thus the database was always touched. Now it is touched only if there are incidence changes.