### PR TITLE
[mkcal] Add missing mKCal namespace to dummystorage. JB#60291

### DIFF
--- a/src/dummystorage.h
+++ b/src/dummystorage.h
@@ -117,15 +117,15 @@ public:
     {
         return true;
     }
-    bool insertNotebook(const Notebook::Ptr &)
+    bool insertNotebook(const mKCal::Notebook::Ptr &)
     {
         return true;
     }
-    bool modifyNotebook(const Notebook::Ptr &)
+    bool modifyNotebook(const mKCal::Notebook::Ptr &)
     {
         return true;
     }
-    bool eraseNotebook(const Notebook::Ptr &)
+    bool eraseNotebook(const mKCal::Notebook::Ptr &)
     {
         return true;
     }

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -28,8 +28,9 @@
 
 #include <sqlite3.h>
 
+#include "dummystorage.h" // Not used, but tests API compilation
+
 #include "tst_storage.h"
-#include "dummystorage.h" // Not used, but tests API compilqtion
 #include "sqlitestorage.h"
 #include "sqliteformat.h"
 #ifdef TIMED_SUPPORT


### PR DESCRIPTION
Apparently the unit test didn't test the compilation good enough in depending projects.

@dcaliste 