### PR TITLE
Don't reload event by UID if already in memory.

### DIFF
--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -404,8 +404,6 @@ private:
 "select * from Calendars order by Name"
 #define SELECT_COMPONENTS_ALL \
 "select * from Components where DateDeleted=0"
-#define SELECT_COMPONENTS_BY_NOTEBOOK \
-"select * from Components where Notebook=? and DateDeleted=0"
 #define SELECT_COMPONENTS_ALL_DELETED \
 "select * from Components where DateDeleted<>0"
 #define SELECT_COMPONENTS_ALL_DELETED_BY_NOTEBOOK \

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -359,6 +359,14 @@ bool SqliteStorage::load(const QString &uid)
         return false;
     }
 
+    // Don't reload an existing incidence from DB.
+    // Either the calendar is already in sync with
+    // the calendar or the database has been externally
+    // modified and in that case, the calendar has been emptied.
+    if (calendar()->incidence(uid)) {
+        return true;
+    }
+
     int rv = 0;
     int count = -1;
     d->mIsLoading = true;

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -1037,8 +1037,8 @@ bool SqliteStorage::allIncidences(Incidence::List *list, const QString &notebook
         bool success = false;
 
         if (!notebookUid.isEmpty()) {
-            query1 = SELECT_COMPONENTS_BY_NOTEBOOK;
-            qsize1 = sizeof(SELECT_COMPONENTS_BY_NOTEBOOK);
+            query1 = SELECT_COMPONENTS_BY_NOTEBOOKUID;
+            qsize1 = sizeof(SELECT_COMPONENTS_BY_NOTEBOOKUID);
         } else {
             query1 = SELECT_COMPONENTS_ALL;
             qsize1 = sizeof(SELECT_COMPONENTS_ALL);


### PR DESCRIPTION
Don't reload an existing incidence from DB.
    Either the calendar is already in sync with
    the calendar or the database has been externally
    modified and in that case, the calendar has been
    emptied.
    
Testing the parent incidence in case of recurring
    incidence should be enough to guarantee the
    existence of all exceptions since the load
    methods ensure loading of whole series.

@pvuorela, tests are passing and this PR follow the same spirit as the one introducing the caching for ranges, meaning that there is no point in reloading if we assume that the calendar is in sync with the DB. It is a minor optimisation that should not cost too much in term of maintainablity. It may not be so minor though for search cases where there could be large quantity of events to load by UIDs.