### PR TITLE
[mkcal] Fix alarm setting for recurring events.

### DIFF
--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -705,13 +705,10 @@ void ExtendedStorage::Private::addAlarms(const Incidence::Ptr &incidence,
         }
 
         QDateTime preTime = laterThan;
-        if (incidence->recurs()) {
-            QDateTime nextRecurrence = incidence->recurrence()->getNextDateTime(laterThan);
-            if (nextRecurrence.isValid() && alarm->startOffset().asSeconds() < 0) {
-                if (laterThan.addSecs(::abs(alarm->startOffset().asSeconds())) >= nextRecurrence) {
-                    preTime = nextRecurrence;
-                }
-            }
+        if (incidence->recurs() && alarm->startOffset().asSeconds() < 0) {
+            // by construction for recurring events, laterThan is the time of the
+            // actual next occurrence, so one need to remove the alarm offset.
+            preTime = preTime.addSecs(alarm->startOffset().asSeconds());
         }
 
         // nextTime() is returning time strictly later than its argument.

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -1819,7 +1819,7 @@ void tst_storage::tst_recurringAlarms()
     ev->recurrence()->setDaily(1);
     KCalendarCore::Alarm::Ptr alarm = ev->newAlarm();
     alarm->setDisplayAlarm(QLatin1String("Testing alarm"));
-    alarm->setStartOffset(KCalendarCore::Duration(0));
+    alarm->setStartOffset(KCalendarCore::Duration(-600));
     alarm->setEnabled(true);
     QVERIFY(m_calendar->addEvent(ev, uid));
     QVERIFY(m_storage->save());


### PR DESCRIPTION
As described in https://forum.sailfishos.org/t/calendar-alarms-dont-work-if-reminder-time-is-in-previous-month-e-g-event-on-april-1-1-00-and-reminder-two-hours-earlier-i-e-on-march-31-23-00/15263/11 , I created a major bug for alarms on recurring events with firing time strictly before the event time.

The bug was in the `addAlarms()` routine in the branch of specific recurring events with a strictly negative alarm offset. It was due to `Recurrence::getNextDateTime()` that returns a date time strictly later than its argument, while I thought it was returning a date time greater or equal than its argument. It was not seen with the tests since I created them for an alarm on the time of the event… My bad, really :/

The fix I'm proposing is a bit simpler than the existing code. Assuming that the `laterThan` argument is always the enxt occurrence for a recurring event, we just have to remove the alarm offset, to be sure that alarm->nextTime() will work.

@pvuorela , I'm sorry for this severe regression in 4.5.0. Hopefully it may find its way in a future hotfix if you judge so.