### PR TITLE
[mkcal] Don't emit storageModified on notebook change.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(mkcal
-	VERSION 0.7.19
+	VERSION 0.7.22
 	DESCRIPTION "Mkcal calendar library")
 
 set(CMAKE_AUTOMOC ON)

--- a/rpm/mkcal-qt5.spec
+++ b/rpm/mkcal-qt5.spec
@@ -1,7 +1,7 @@
 Name:       mkcal-qt5
 
 Summary:    SQlite storage backend for KCalendarCore
-Version:    0.7.19
+Version:    0.7.22
 Release:    1
 License:    LGPLv2+
 URL:        https://github.com/sailfishos/mkcal

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -1307,11 +1307,7 @@ bool SqliteStorage::Private::saveNotebook(const Notebook::Ptr &nb, DBOperation d
         sqlite3_finalize(stmt);
 
         if (success) {
-            // Don't save the incremented transactionId at the moment,
-            // let it be seen as an external modification.
-            // Todo: add a method for observers on notebook changes.
-            if (!mFormat->incrementTransactionId(nullptr))
-                mSavedTransactionId = -1;
+            mFormat->incrementTransactionId(&mSavedTransactionId);
         }
 
         if (!mSem.release()) {

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -2278,6 +2278,21 @@ void tst_storage::tst_storageObserver()
     QVERIFY(modified.isEmpty());
     QVERIFY(!modified.wait(200));
 
+    mKCal::Notebook::Ptr notebook(new mKCal::Notebook(QString::fromLatin1("signals"),
+                                                      QString()));
+    m_storage->addNotebook(notebook);
+    QVERIFY(modified.isEmpty());
+    QVERIFY(!modified.wait(200));
+
+    notebook->setDescription(QString::fromLatin1("testing signals"));
+    m_storage->updateNotebook(notebook);
+    QVERIFY(modified.isEmpty());
+    QVERIFY(!modified.wait(200));
+
+    m_storage->deleteNotebook(notebook);
+    QVERIFY(modified.isEmpty());
+    QVERIFY(!modified.wait(200));
+
     mKCal::ExtendedCalendar::Ptr calendar(new mKCal::ExtendedCalendar(QTimeZone::systemTimeZone()));
     mKCal::ExtendedStorage::Ptr storage = mKCal::ExtendedCalendar::defaultStorage(calendar);
     QVERIFY(storage->open());


### PR DESCRIPTION
Like for events, there is no need to ask for
a complete calendar reset on a notebook change
since the modifications are known by the caller.

storageModified should be restricted for out
of process changes.

@pvuorela, since we're at cleaning mKCal API and behaviour, I would like to update the emitted signals on notebook changes. Currently a `storageModified()` signal is emitted, which means for clients "unknown database changes, please reset everything and reload". At first I wanted to create a new signal like the one existing for events (`storageUpdated()`) to notify for the notebook change, but I think there is no need. Clients making notebook changes know the change done since the API is synchronous in contrary to the event one which piles up changes done to the calendar and commit with the `save()` call.

In practice, the only client that requires to update something on a notebook change is the QML binding one. As far as I know, the Buteo sync plugins don't wait for a calendar wipe out on a notebook change. So I'm creating sailfishos/nemo-qml-plugin-calendar#58 to handle this.