### PR TITLE
[mkcal] Move alarm handling to a new class.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRC
 	sqliteformat.cpp
 	sqlitestorage.cpp
 	servicehandler.cpp
+        alarmhandler.cpp
 	logging.cpp
 	semaphore_p.cpp)
 set(HEADERS
@@ -20,6 +21,7 @@ set(HEADERS
 	invitationhandlerif.h)
 
 set(PRIVATE_HEADERS
+        alarmhandler_p.h
         logging_p.h
         semaphore_p.h
         sqliteformat.h

--- a/src/alarmhandler.cpp
+++ b/src/alarmhandler.cpp
@@ -1,0 +1,320 @@
+/*
+  This file is part of the mkcal library.
+
+  Copyright (c) 2023 Damien Caliste <dcaliste@free.fr>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Library General Public
+  License as published by the Free Software Foundation; either
+  version 2 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Library General Public License for more details.
+
+  You should have received a copy of the GNU Library General Public License
+  along with this library; see the file COPYING.LIB.  If not, write to
+  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+  Boston, MA 02110-1301, USA.
+*/
+
+#include "alarmhandler_p.h"
+#include "logging_p.h"
+
+using namespace mKCal;
+
+#include <KCalendarCore/Todo>
+using namespace KCalendarCore;
+
+#ifdef TIMED_SUPPORT
+# include <timed-qt5/interface.h>
+# include <timed-qt5/event-declarations.h>
+# include <timed-qt5/exception.h>
+# include <QtCore/QMap>
+# include <QtDBus/QDBusReply>
+using namespace Maemo;
+static const QLatin1String RESET_ALARMS_CMD("invoker --type=generic -n /usr/bin/mkcaltool --reset-alarms");
+#endif
+
+bool AlarmHandler::clearAlarms(const QString &notebookUid, const QString &uid)
+{
+#if defined(TIMED_SUPPORT)
+    Timed::Interface timed;
+    if (!timed.isValid()) {
+        qCWarning(lcMkcal) << "cannot clear alarms,"
+                 << "timed interface is not valid" << timed.lastError();
+        return false;
+    }
+
+    QMap<QString, QVariant> query;
+    query["APPLICATION"] = "libextendedkcal";
+    query["notebook"] = notebookUid;
+    if (!uid.isEmpty()) {
+        query["uid"] = uid;
+    }
+    QDBusReply<QList<QVariant> > reply = timed.query_sync(query);
+    if (!reply.isValid()) {
+        qCWarning(lcMkcal) << "cannot get alarm cookies" << timed.lastError();
+        return false;
+    }
+    QList<uint> cookies;
+    for (const QVariant &variant : reply.value()) {
+        cookies.append(variant.toUInt());
+    }
+    if (!cookies.isEmpty()) {
+        QDBusReply<QList<uint>> reply = timed.cancel_events_sync(cookies);
+        if (!reply.isValid() || !reply.value().isEmpty()) {
+            qCWarning(lcMkcal) << "cannot remove alarms" << cookies;
+        }
+    }
+#endif
+    return true;
+}
+
+static bool cancelAlarms(const QSet<QPair<QString, QString>> &uids)
+{
+#if defined(TIMED_SUPPORT)
+    if (uids.count() == 1) {
+        QPair<QString, QString> id = uids.values()[0];
+        return AlarmHandler::clearAlarms(id.first, id.second);
+    }
+
+    Timed::Interface timed;
+    if (!timed.isValid()) {
+        qCWarning(lcMkcal) << "cannot clear alarms,"
+                 << "timed interface is not valid" << timed.lastError();
+        return false;
+    }
+
+    QMap<QString, QVariant> query;
+    query["APPLICATION"] = "libextendedkcal";
+    QDBusReply<QList<QVariant> > reply = timed.query_sync(query);
+    if (!reply.isValid()) {
+        qCWarning(lcMkcal) << "cannot get alarm cookies" << timed.lastError();
+        return false;
+    }
+    QList<uint> cookiesAll;
+    for (const QVariant &variant : reply.value()) {
+        cookiesAll.append(variant.toUInt());
+    }
+    QDBusReply<QMap<uint, QMap<QString,QString> >> attributes = timed.get_attributes_by_cookies_sync(cookiesAll);
+    if (!attributes.isValid()) {
+        qCWarning(lcMkcal) << "cannot get alarm attributes" << timed.lastError();
+        return false;
+    }
+    QList<uint> cookiesDoomed;
+    const QMap<uint, QMap<QString,QString> > map = attributes.value();
+    for (QMap<uint, QMap<QString,QString> >::ConstIterator it = map.constBegin();
+         it != map.constEnd(); it++) {
+        const QString notebook = it.value()["notebook"];
+        const QString uid = it.value()["uid"];
+
+        if (uids.contains(QPair<QString, QString>(notebook, uid))
+            || uids.contains(QPair<QString, QString>(notebook, QString()))) {
+            qCDebug(lcMkcal) << "removing alarm" << it.key() << notebook << uid;
+            cookiesDoomed.append(it.key());
+        }
+    }
+    if (!cookiesDoomed.isEmpty()) {
+        QDBusReply<QList<uint>> reply = timed.cancel_events_sync(cookiesDoomed);
+        if (!reply.isValid() || !reply.value().isEmpty()) {
+            qCWarning(lcMkcal) << "cannot remove alarms" << cookiesDoomed;
+        }
+    }
+#endif
+    return true;
+}
+
+#if defined(TIMED_SUPPORT)
+static QDateTime getNextOccurrence(const Recurrence *recurrence,
+                                   const QDateTime &start,
+                                   const QSet<QDateTime> &recurrenceIds)
+{
+    QDateTime match = start;
+    if (!recurrence->recursAt(start) || recurrenceIds.contains(start)) {
+        do {
+            match = recurrence->getNextDateTime(match);
+        } while (match.isValid() && recurrenceIds.contains(match));
+    }
+    return match;
+}
+
+static void addAlarms(Timed::Event::List *events,
+                      const QString &notebookUid, const Incidence &incidence,
+                      const QDateTime &laterThan)
+{
+    if (incidence.status() == Incidence::StatusCanceled || laterThan.isNull()) {
+        return;
+    }
+
+    const QDateTime now = QDateTime::currentDateTime();
+    const Alarm::List alarms = incidence.alarms();
+    foreach (const Alarm::Ptr alarm, alarms) {
+        if (!alarm->enabled()) {
+            continue;
+        }
+
+        QDateTime preTime = laterThan;
+        if (incidence.recurs() && alarm->startOffset().asSeconds() < 0) {
+            // by construction for recurring events, laterThan is the time of the
+            // actual next occurrence, so one need to remove the alarm offset.
+            preTime = preTime.addSecs(alarm->startOffset().asSeconds());
+        }
+
+        // nextTime() is returning time strictly later than its argument.
+        QDateTime alarmTime = alarm->nextTime(preTime.addSecs(-1), true);
+        if (!alarmTime.isValid()) {
+            continue;
+        }
+
+        if (now.addSecs(60) > alarmTime) {
+            // don't allow alarms within the current minute -> take next alarm if so
+            alarmTime = alarm->nextTime(preTime.addSecs(60), true);
+            if (!alarmTime.isValid()) {
+                continue;
+            }
+        }
+        Timed::Event &e = events->append();
+        e.setUserModeFlag();
+        e.setMaximalTimeoutSnoozeCounter(2);
+        e.setTicker(alarmTime.toUTC().toTime_t());
+        // The code'll crash (=exception) iff the content is empty. So
+        // we have to check here.
+        QString s;
+
+        s = incidence.summary();
+        // Timed braindeath: Required field, BUT if empty, it asserts
+        if (s.isEmpty()) {
+            s = ' ';
+        }
+        e.setAttribute("TITLE", s);
+        e.setAttribute("PLUGIN", "libCalendarReminder");
+        e.setAttribute("APPLICATION", "libextendedkcal");
+        //e.setAttribute( "translation", "organiser" );
+        // This really has to exist or code is badly broken
+        Q_ASSERT(!incidence.uid().isEmpty());
+        e.setAttribute("uid", incidence.uid());
+#ifndef QT_NO_DEBUG_OUTPUT //Helps debuggin
+        e.setAttribute("alarmtime", alarmTime.toTimeSpec(Qt::OffsetFromUTC).toString(Qt::ISODate));
+#endif
+        if (!incidence.location().isEmpty()) {
+            e.setAttribute("location", incidence.location());
+        }
+        if (incidence.recurs()) {
+            e.setAttribute("recurs", "true");
+            Timed::Event::Action &a = e.addAction();
+            a.runCommand(QString("%1 %2 %3")
+                         .arg(RESET_ALARMS_CMD)
+                         .arg(notebookUid)
+                         .arg(incidence.uid()));
+            a.whenServed();
+        }
+
+        // TODO - consider this how it should behave for recurrence
+        if ((incidence.type() == Incidence::TypeTodo)) {
+            const Todo *todo = static_cast<const Todo*>(&incidence);
+
+            if (todo->hasDueDate()) {
+                e.setAttribute("time", todo->dtDue(true).toTimeSpec(Qt::OffsetFromUTC).toString(Qt::ISODate));
+            }
+            e.setAttribute("type", "todo");
+        } else if (incidence.dtStart().isValid()) {
+            QDateTime eventStart;
+
+            if (incidence.recurs()) {
+                // assuming alarms not later than event start
+                eventStart = incidence.recurrence()->getNextDateTime(alarmTime.addSecs(-60));
+            } else {
+                eventStart = incidence.dtStart();
+            }
+            e.setAttribute("time", eventStart.toTimeSpec(Qt::OffsetFromUTC).toString(Qt::ISODate));
+            e.setAttribute("startDate", eventStart.toTimeSpec(Qt::OffsetFromUTC).toString(Qt::ISODate));
+            if (incidence.endDateForStart(eventStart).isValid()) {
+                e.setAttribute("endDate", incidence.endDateForStart(eventStart).toTimeSpec(Qt::OffsetFromUTC).toString(Qt::ISODate));
+            }
+            e.setAttribute("type", "event");
+        }
+
+        if (incidence.hasRecurrenceId()) {
+            e.setAttribute("recurrenceId", incidence.recurrenceId().toString(Qt::ISODate));
+        }
+        e.setAttribute("notebook", notebookUid);
+
+        if (alarm->type() == Alarm::Procedure) {
+            QString prog = alarm->programFile();
+            if (!prog.isEmpty()) {
+                Timed::Event::Action &a = e.addAction();
+                a.runCommand(prog + " " + alarm->programArguments());
+                a.whenFinalized();
+            }
+        } else {
+            e.setReminderFlag();
+            e.setAlignedSnoozeFlag();
+        }
+    }
+}
+#endif
+
+bool AlarmHandler::setupAlarms(const QString &notebookUid, const QString &uid)
+{
+    QSet<QPair<QString, QString>> uids;
+    uids.insert(QPair<QString, QString>(notebookUid, uid));
+    return setupAlarms(uids);
+}
+
+bool AlarmHandler::setupAlarms(const QSet<QPair<QString, QString>> &uids)
+{
+#if defined(TIMED_SUPPORT)
+    cancelAlarms(uids);
+
+    const QDateTime now = QDateTime::currentDateTime();
+    Timed::Event::List events;
+    for (QSet<QPair<QString, QString>>::ConstIterator it = uids.constBegin();
+         it != uids.constEnd(); it++) {
+        Incidence::List list = incidencesWithAlarms(it->first, it->second);
+        QSet<QDateTime> recurrenceIds;
+        for (Incidence::List::ConstIterator inc = list.constBegin();
+             inc != list.constEnd(); inc++) {
+            if ((*inc)->hasRecurrenceId()) {
+                recurrenceIds.insert((*inc)->recurrenceId());
+            }
+        }
+        for (Incidence::List::ConstIterator inc = list.constBegin();
+             inc != list.constEnd(); inc++) {
+            if ((*inc)->recurs()) {
+                addAlarms(&events, it->first, **inc,
+                          getNextOccurrence((*inc)->recurrence(), now, recurrenceIds));
+            } else {
+                addAlarms(&events, it->first, **inc, now);
+            }
+        }
+    }
+    if (events.count() > 0) {
+        Timed::Interface timed;
+        if (!timed.isValid()) {
+            qCWarning(lcMkcal) << "cannot set alarm for incidence: "
+                               << "alarm interface is not valid" << timed.lastError();
+            return false;
+        }
+        QDBusReply < QList<QVariant> > reply = timed.add_events_sync(events);
+        if (reply.isValid()) {
+            foreach (QVariant v, reply.value()) {
+                bool ok = true;
+                uint cookie = v.toUInt(&ok);
+                if (ok && cookie) {
+                    qCDebug(lcMkcal) << "added alarm: " << cookie;
+                } else {
+                    qCWarning(lcMkcal) << "failed to add alarm";
+                }
+            }
+        } else {
+            qCWarning(lcMkcal) << "failed to add alarms: " << reply.error().message();
+            return false;
+        }
+    } else {
+        qCDebug(lcMkcal) << "No alarms to send";
+    }
+#endif
+    return true;
+}

--- a/src/alarmhandler_p.h
+++ b/src/alarmhandler_p.h
@@ -1,0 +1,97 @@
+/*
+  This file is part of the mkcal library.
+
+  Copyright (c) 2023 Damien Caliste <dcaliste@free.fr>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Library General Public
+  License as published by the Free Software Foundation; either
+  version 2 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Library General Public License for more details.
+
+  You should have received a copy of the GNU Library General Public License
+  along with this library; see the file COPYING.LIB.  If not, write to
+  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+  Boston, MA 02110-1301, USA.
+*/
+/**
+  @file
+  This file is part of the API for handling alarms.
+
+  @author Damien Caliste \<dcaliste@free.fr\>
+*/
+
+#ifndef MKCAL_ALARMHANDLER_H
+#define MKCAL_ALARMHANDLER_H
+
+#include <KCalendarCore/Incidence>
+
+#include "mkcal_export.h"
+
+namespace mKCal {
+
+/**
+  @brief
+  This class provides an interface to handle alarms.
+*/
+class AlarmHandler
+{
+protected:
+    AlarmHandler() { }
+
+    virtual ~AlarmHandler() { }
+
+    /**
+      Implement this method to provide incidences with alarms to the alarm handler.
+
+      This method is called internally from setupAlarms() to get the
+      information from a storage to setup alarms. Implementers of this
+      class should guarantee that the series corresponding to uid is
+      in memory when calling setupAlarms() with a non-empty uid, or calling
+      setupAlarms() with several uids. If uid is empty, there is no guarantee
+      given on the availablity of all incidences at the moment of the call.
+
+      @param notebookUid, return incidence belonging to this notebook.
+      @param uid, when not empty, restrict the returned incidences to
+             incidences sharing this UID.
+      @returns a list of incidences with an alarm.
+     */
+    virtual KCalendarCore::Incidence::List incidencesWithAlarms(const QString &notebookUid,
+                                                                const QString &uid = QString()) = 0;
+
+public:
+    /**
+      Remove alarms from a given notebook.
+
+      @param notebookUid, the notebook UID the alarms to remove belong to.
+      @param uid, when not empty, restrict the removal to incidences with this UID.
+      @returns true on success.
+     */
+    static bool clearAlarms(const QString &notebookUid, const QString &uid = QString());
+
+    /**
+      Create alarms for all incidence of a notebook, or to a series in this notebook.
+
+      @param notebookUid, the notebook UID the alarms to be create from.
+      @param uid, when not empty, create alarms only for incidence with this UID.
+      @returns true on success.
+     */
+    bool setupAlarms(const QString &notebookUid, const QString &uid = QString());
+
+    /**
+      Create alarms for a set of incidences known by the notebook
+      they belong to and their UID.
+
+      @param uids, a set of tuple (notebookUid, incidenceUid).
+      @returns true on success.
+     */
+    bool setupAlarms(const QSet<QPair<QString, QString>> &uids);
+};
+
+}
+
+#endif


### PR DESCRIPTION
Also change the alarm setting behaviour.
Instead of dealing per incidence, it is
now clearing and setting alarms per UID.

If an incidence recurs and has exceptions,
all alarms sharing the same UID are removed
and then parent and all exceptions are reset.

@pvuorela , yet another spin off from #61.

In the current alarm code, a KCalendarCore::Calendar is required for two things:
- to get the `notebookUid` associated to a given incidence,
- to get the `instances()` list of a recurring incidence, so its next occurrence can be recalculated.

In the context of the coming changes, there won't be necessary a unique KCalendarCore::Calendar that stores the incidences. So I tried to remove it from the alarm API:
- the notebook uid is thus pass in the way of `QPAir<QString, QString>` where the first element is the notebook uid and the second the incidence uid.
- the `instances()` are retrieved by a convenient routine that implementers of AlarmHandler are providing. This routine either reread the DB (in the case where we change all alarms of a notebook, as it was done before), or return the full series for a given UID as in memory.

As mentioned in #61, I'm also changing the behaviour to avoid doing per incidence alarm, and move to a per series alarm. In my opinion, this is less error-prone, with less cases to be treated. Just a clear all alarms with this NBUID/UID tuple, reset all alarms for the list of incidence sharing this NBUID/UID tuple.