### PR TITLE
[mkcal] Fix deleteAllIncidences().

### DIFF
--- a/src/extendedcalendar.cpp
+++ b/src/extendedcalendar.cpp
@@ -260,19 +260,9 @@ bool ExtendedCalendar::addJournal(const Journal::Ptr &aJournal, const QString &n
 
 void ExtendedCalendar::deleteAllIncidences()
 {
-    const Event::List events = rawEvents();
-    for (const Event::Ptr &ev : events) {
-        notifyIncidenceDeleted(ev);
+    for (const Incidence::Ptr &incidence : incidences()) {
+        deleteIncidence(incidence);
     }
-    const Todo::List todos = rawTodos();
-    for (const Todo::Ptr &todo : todos) {
-        notifyIncidenceDeleted(todo);
-    }
-    const Journal::List journals = rawJournals();
-    for (const Journal::Ptr &journal : journals) {
-        notifyIncidenceDeleted(journal);
-    }
-    close();
 }
 
 Incidence::List ExtendedCalendar::incidences(const QDate &start, const QDate &end)


### PR DESCRIPTION
Since close() is actually removing the notebook
associations to incidences, and since now mKCal
delete incidences with UID and notebookId, the
current implementation of deleteAllIncidences()
was failing.

@pvuorela and @rainemak, I believe this fix the reported issue of webCAL entries multiplying themselves on sync. The entries were not removed from the database, because the notebook id passed to the SqliteFormat::modifyComponents() was empty, and thus this method was not finding the incidences to delete and considered them already deleted.

@pvuorela, I think the deleteAllIncidences() is only used in the buteo-sync-plugin-webcal. Since, it's a thin wrapper now, one may even remove it from ExtendedCalendar API and put the for loop inside Buteo plugin. What do you think ?