### PR TITLE
[mkcal] Remove deleteAllIncidence() API.

### DIFF
--- a/src/extendedcalendar.cpp
+++ b/src/extendedcalendar.cpp
@@ -258,13 +258,6 @@ bool ExtendedCalendar::addJournal(const Journal::Ptr &aJournal, const QString &n
     }
 }
 
-void ExtendedCalendar::deleteAllIncidences()
-{
-    for (const Incidence::Ptr &incidence : incidences()) {
-        deleteIncidence(incidence);
-    }
-}
-
 Incidence::List ExtendedCalendar::incidences(const QDate &start, const QDate &end)
 {
     return mergeIncidenceList(events(start, end), todos(start, end), journals(start, end));

--- a/src/extendedcalendar.h
+++ b/src/extendedcalendar.h
@@ -273,12 +273,6 @@ public:
     */
     bool addIncidence(const KCalendarCore::Incidence::Ptr &incidence, const QString &notebookUid);
 
-    /**
-      Delete all incidences from the memory cache. They will be deleted from
-      database when save is called.
-    */
-    void deleteAllIncidences();
-
     // Event Specific Methods //
 
     /**

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -1654,7 +1654,8 @@ void tst_storage::tst_deleteAllEvents()
     QCOMPARE(cal->incidences().count(), 1);
     QCOMPARE(cal->rawEventsForDate(ev->dtStart().date()).count(), 1);
 
-    cal->deleteAllIncidences();
+    for (const KCalendarCore::Incidence::Ptr &incidence : cal->incidences())
+        cal->deleteIncidence(incidence);
     QVERIFY(cal->incidences().isEmpty());
     QVERIFY(cal->rawEventsForDate(ev->dtStart().date()).isEmpty());
 }


### PR DESCRIPTION
It is only a thin wrapper around a loop
over all incidences. It can be removed
to avoid confusion on what incidences are
actually deleted and from where.

It also helps to reduce the delta in API
with upstream Calendar class.