### PR TITLE
Support more mkcal specific database override variable

### DIFF
--- a/rpm/mkcal-qt5.spec
+++ b/rpm/mkcal-qt5.spec
@@ -1,7 +1,7 @@
 Name:       mkcal-qt5
 
 Summary:    SQlite storage backend for KCalendarCore
-Version:    0.7.22
+Version:    0.7.27
 Release:    1
 License:    LGPLv2+
 URL:        https://github.com/sailfishos/mkcal
@@ -46,10 +46,9 @@ This package contains unit tests for extended KDE kcal calendar library.
 
 %build
 %cmake -DINSTALL_TESTS=ON
-make %{?_smp_mflags}
+%make_build
 
 %install
-rm -rf %{buildroot}
 %make_install
 
 mkdir -p %{buildroot}%{_datadir}/mapplauncherd/privileges.d
@@ -60,7 +59,6 @@ install -m 644 -p %{SOURCE1} %{buildroot}%{_datadir}/mapplauncherd/privileges.d/
 %postun -p /sbin/ldconfig
 
 %files
-%defattr(-,root,root,-)
 %license LICENSE.LGPL2
 %{_libdir}/lib%{name}.so.*
 %{_libdir}/mkcalplugins/*.so
@@ -68,13 +66,11 @@ install -m 644 -p %{SOURCE1} %{buildroot}%{_datadir}/mapplauncherd/privileges.d/
 %{_datadir}/mapplauncherd/privileges.d/*
 
 %files devel
-%defattr(-,root,root,-)
 %{_includedir}/%{name}
 %{_libdir}/lib%{name}.so
 %{_libdir}/pkgconfig/*.pc
 
 %files tests
-%defattr(-,root,root,-)
 /opt/tests/mkcal/tst_load
 /opt/tests/mkcal/tst_perf
 /opt/tests/mkcal/tst_storage

--- a/src/invitationhandlerif.h
+++ b/src/invitationhandlerif.h
@@ -58,7 +58,8 @@ public:
         @param body The body of the reply, if any
         @return True if OK, false otherwise.
     */
-  virtual bool sendInvitation(const QString &accountId, const QString &notebookUid, const KCalendarCore::Incidence::Ptr &invitation, const QString &body) =0;
+  virtual bool sendInvitation(const QString &accountId, const QString &notebookUid,
+                              const KCalendarCore::Incidence::Ptr &invitation, const QString &body) = 0;
 
     /** \brief Send a updated invitation to all the participants.
         This is used for updating invitations we sent earlier.
@@ -68,7 +69,8 @@ public:
         @param body The body of the reply, if any
         @return True if OK, false otherwise.
     */
-  virtual bool sendUpdate(const QString &accountId, const KCalendarCore::Incidence::Ptr &invitation, const QString &body) = 0;
+  virtual bool sendUpdate(const QString &accountId, const KCalendarCore::Incidence::Ptr &invitation,
+                          const QString &body) = 0;
 
     /** \brief Send the updated invitation back to the Organiser.
         The attendance values should have been updated earlier by the caller.
@@ -78,7 +80,8 @@ public:
         @param body The body of the reply, if any
         @return True if OK, false otherwise.
       */
-  virtual bool sendResponse(const QString &accountId, const KCalendarCore::Incidence::Ptr &invitation, const QString &body) = 0;
+  virtual bool sendResponse(const QString &accountId, const KCalendarCore::Incidence::Ptr &invitation,
+                            const QString &body) = 0;
 
     /** \brief The name of this plugin.
         It should be a uniq name specifying which plugin to use for sending invitations.

--- a/src/servicehandler.h
+++ b/src/servicehandler.h
@@ -50,7 +50,6 @@ private:
     ServiceHandlerPrivate *const d;
 
 public:
-
     /** Error Codes that can be returned by the plugins */
     //Right now they are the same as defined in ServiceHandlerIf
     //But semantically it doesn't make sense that they are defined
@@ -79,7 +78,8 @@ public:
       @param body The body of the reply if any
       @return True if OK, false in case of error
       */
-    bool sendInvitation(const Notebook::Ptr &notebook, const KCalendarCore::Incidence::Ptr &invitation, const QString &body);
+    bool sendInvitation(const Notebook::Ptr &notebook, const KCalendarCore::Incidence::Ptr &invitation,
+                        const QString &body);
 
     /** Send the updated invitation to the list of people stated as attendees.
       @param notebook notebook to use for account info
@@ -87,7 +87,8 @@ public:
       @param body The body of the reply if any
       @return True if OK, false in case of error
       */
-    bool sendUpdate(const Notebook::Ptr &notebook, const KCalendarCore::Incidence::Ptr &invitation, const QString &body);
+    bool sendUpdate(const Notebook::Ptr &notebook, const KCalendarCore::Incidence::Ptr &invitation,
+                    const QString &body);
 
     /** Send the updated invitation to the organiser.
       @param notebook notebook to use for account info
@@ -95,7 +96,8 @@ public:
       @param body The body of the reply if any
       @return True if OK, false in case of error
       */
-    bool sendResponse(const Notebook::Ptr &notebook, const KCalendarCore::Incidence::Ptr &invitation, const QString &body);
+    bool sendResponse(const Notebook::Ptr &notebook, const KCalendarCore::Incidence::Ptr &invitation,
+                      const QString &body);
 
     /** Icon
       @param serviceId the name of the service to use

--- a/src/servicehandlerif.h
+++ b/src/servicehandlerif.h
@@ -79,7 +79,7 @@ public:
         This name is something to be show to the user
         @return true is service supports multiple calendars otherwise false.
     */
-    virtual  bool multiCalendar() const = 0;
+    virtual bool multiCalendar() const = 0;
 
     /** \brief returns the email address that is currently configured in the service,
         it can be different per account.

--- a/src/sqlitestorage.cpp
+++ b/src/sqlitestorage.cpp
@@ -164,7 +164,11 @@ static bool directoryIsRW(const QString &dirPath)
 static QString defaultLocation()
 {
     // Environment variable is taking precedence.
-    QString dbFile = QLatin1String(qgetenv("SQLITESTORAGEDB"));
+    QString dbFile = QLatin1String(qgetenv("MKCAL_STORAGEDB"));
+    if (dbFile.isEmpty()) {
+        // older env variable as fallback
+        dbFile = QLatin1String(qgetenv("SQLITESTORAGEDB"));
+    }
     if (dbFile.isEmpty()) {
         // Otherwise, use a central storage location by default
         const QString privilegedDataDir = QString("%1/.local/share/system/privileged/").arg(QDir::homePath());

--- a/tests/tests.xml
+++ b/tests/tests.xml
@@ -3,13 +3,13 @@
   <suite name="mkcal-qt5" domain="mw">
     <set name="unit-tests" feature="mkcal">
        <case manual="false" name="tst_storage">
-         <step>rm -f /tmp/testdb; SQLITESTORAGEDB=/tmp/testdb /opt/tests/mkcal/tst_storage</step>
+         <step>rm -f /tmp/testdb; MKCAL_STORAGEDB=/tmp/testdb /opt/tests/mkcal/tst_storage</step>
        </case>
        <case manual="false" name="tst_load">
-         <step>rm -f /tmp/testdb; SQLITESTORAGEDB=/tmp/testdb /opt/tests/mkcal/tst_load</step>
+         <step>rm -f /tmp/testdb; MKCAL_STORAGEDB=/tmp/testdb /opt/tests/mkcal/tst_load</step>
        </case>
        <case manual="false" name="tst_perf">
-         <step>rm -f /tmp/testdb; SQLITESTORAGEDB=/tmp/testdb /opt/tests/mkcal/tst_perf</step>
+         <step>rm -f /tmp/testdb; MKCAL_STORAGEDB=/tmp/testdb /opt/tests/mkcal/tst_perf</step>
        </case>
      </set>
   </suite>

--- a/tests/tst_perf.cpp
+++ b/tests/tst_perf.cpp
@@ -35,7 +35,7 @@ static const int N_EVENTS = 200;
 
 void tst_perf::initTestCase()
 {
-    QString dbFile = QString::fromLatin1(qgetenv("SQLITESTORAGEDB"));
+    QString dbFile = QString::fromLatin1(qgetenv("MKCAL_STORAGEDB"));
     if (dbFile.isEmpty()) {
         db = new QTemporaryFile();
         db->open();

--- a/tests/tst_perf.cpp
+++ b/tests/tst_perf.cpp
@@ -80,11 +80,11 @@ void tst_perf::tst_save()
         event->setSummary(QString::fromLatin1("summary"));
         event->setNonKDECustomProperty("X-FOO", QString::fromLatin1("a property value"));
         event->setCustomProperty("VOLATILE", "BAR", QString::fromLatin1("another property value"));
-        if (i%3 == 0) {
+        if (i % 3 == 0) {
             KCalendarCore::Alarm::Ptr alarm = event->newAlarm();
             alarm->setDisplayAlarm(QString::fromLatin1("Driiiiing"));
         }
-        if (i%5 == 0) {
+        if (i % 5 == 0) {
             event->recurrence()->setWeekly(1, cur.date().dayOfWeek());
             event->recurrence()->setEndDateTime(event->dtEnd().addDays((i + 5) * 7));
             KCalendarCore::Incidence::Ptr exc = m_storage->calendar()->createException(event, cur.addDays(7));

--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -33,6 +33,7 @@
 #include "tst_storage.h"
 #include "sqlitestorage.h"
 #include "sqliteformat.h"
+
 #ifdef TIMED_SUPPORT
 #include <timed-qt5/interface.h>
 #include <QtCore/QMap>

--- a/tools/mkcaltool/mkcaltool.cpp
+++ b/tools/mkcaltool/mkcaltool.cpp
@@ -47,6 +47,7 @@ int MkcalTool::resetAlarms(const QString &notebookUid, const QString &eventUid)
         return 1;
     }
 
-    storage->emitStorageUpdated(KCalendarCore::Incidence::List(), KCalendarCore::Incidence::List() << event, KCalendarCore::Incidence::List());
+    storage->emitStorageUpdated(KCalendarCore::Incidence::List(),
+                                KCalendarCore::Incidence::List() << event, KCalendarCore::Incidence::List());
     return 0;
 }


### PR DESCRIPTION
SQLITESTORAGEDB was overly generic when there can be e.g. unit tests that involve multiple databases. Some cleanups while at it.

cc @dcaliste 