### PR TITLE
Draft: [mkcal] Add an enabled property to Notebooks.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 project(mkcal
-	VERSION 0.7.22
+	VERSION 0.7.28
 	DESCRIPTION "Mkcal calendar library")
 
 set(CMAKE_AUTOMOC ON)

--- a/rpm/mkcal-qt5.spec
+++ b/rpm/mkcal-qt5.spec
@@ -1,7 +1,7 @@
 Name:       mkcal-qt5
 
 Summary:    SQlite storage backend for KCalendarCore
-Version:    0.7.27
+Version:    0.7.28
 Release:    1
 License:    LGPLv2+
 URL:        https://github.com/sailfishos/mkcal

--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -112,6 +112,7 @@ Incidence::List ExtendedStorage::Private::incidencesWithAlarms(const QString &no
 {
     Incidence::List list;
     if (!mNotebooks.contains(notebookUid)
+        || !mNotebooks.value(notebookUid)->isEnabled()
         || !mNotebooks.value(notebookUid)->isVisible()) {
         return list;
     }
@@ -378,8 +379,8 @@ bool ExtendedStorage::addNotebook(const Notebook::Ptr &nb)
     }
 
     d->mNotebooks.insert(nb->uid(), nb);
-    if (!calendar()->addNotebook(nb->uid(), nb->isVisible())
-        && !calendar()->updateNotebook(nb->uid(), nb->isVisible())) {
+    if (!calendar()->addNotebook(nb->uid(), nb->isEnabled() && nb->isVisible())
+        && !calendar()->updateNotebook(nb->uid(), nb->isEnabled() && nb->isVisible())) {
         qCWarning(lcMkcal) << "notebook" << nb->uid() << "already in calendar";
     }
 
@@ -398,14 +399,14 @@ bool ExtendedStorage::updateNotebook(const Notebook::Ptr &nb)
     }
 
     bool wasVisible = calendar()->isVisible(nb->uid());
-    if (!calendar()->updateNotebook(nb->uid(), nb->isVisible())) {
+    if (!calendar()->updateNotebook(nb->uid(), nb->isEnabled() && nb->isVisible())) {
         qCWarning(lcMkcal) << "cannot update notebook" << nb->uid() << "in calendar";
         return false;
     }
 
-    if (wasVisible && !nb->isVisible()) {
+    if (wasVisible && (!nb->isEnabled() || !nb->isVisible())) {
         d->clearAlarms(nb->uid());
-    } else if (!wasVisible && nb->isVisible()) {
+    } else if (!wasVisible && nb->isEnabled() && nb->isVisible()) {
         d->setupAlarms(nb->uid());
     }
 

--- a/src/notebook.cpp
+++ b/src/notebook.cpp
@@ -50,6 +50,7 @@ static const int FLAG_IS_READONLY = (1 << 6);
 static const int FLAG_IS_VISIBLE = (1 << 7);
 static const int FLAG_IS_RUNTIMEONLY = (1 << 8);
 static const int FLAG_IS_SHAREABLE = (1 << 9);
+static const int FLAG_IS_ENABLED = (1 << 10);
 
 #define NOTEBOOK_FLAGS_ALLOW_ALL        \
   ( FLAG_ALLOW_EVENT |                  \
@@ -59,7 +60,8 @@ static const int FLAG_IS_SHAREABLE = (1 << 9);
 #define DEFAULT_NOTEBOOK_FLAGS          \
   ( NOTEBOOK_FLAGS_ALLOW_ALL |          \
     FLAG_IS_MASTER |                    \
-    FLAG_IS_VISIBLE )
+    FLAG_IS_VISIBLE |                   \
+    FLAG_IS_ENABLED)
 
 #define SET_BIT_OR_RETURN(var,bit,value)          \
 do {                                              \
@@ -309,6 +311,17 @@ bool Notebook::isVisible() const
 void Notebook::setIsVisible(bool isVisible)
 {
     SET_BIT_OR_RETURN(d->mFlags, FLAG_IS_VISIBLE, isVisible);
+    d->updateModified();
+}
+
+bool Notebook::isEnabled() const
+{
+    return d->mFlags & FLAG_IS_ENABLED;
+}
+
+void Notebook::setIsEnabled(bool isEnabled)
+{
+    SET_BIT_OR_RETURN(d->mFlags, FLAG_IS_ENABLED, isEnabled);
     d->updateModified();
 }
 

--- a/src/notebook.h
+++ b/src/notebook.h
@@ -197,18 +197,33 @@ public:
     void setIsReadOnly(bool isReadOnly);
 
     /**
-      Returns true if notebook is visible.
+      Returns true if incidence of this notebook are visible.
       @see setIsVisible().
     */
     bool isVisible() const;
 
     /**
-      Set notebook visibility.
+      Set notebook incidence visibility.
       Calendar will check this value for including/excluding incidences
       into search lists.
       @param isVisible true to set visible mode.
     */
     void setIsVisible(bool isVisible);
+
+    /**
+      Returns true if this notebook is enabled (disabling a calendar is
+      a hint not to show the calendar to the user).
+      @see setIsEnabled().
+    */
+    bool isEnabled() const;
+
+    /**
+      Set if notebook is enabled.
+      Disabling a calendar is a hint not to show the calendar to the user. It is
+      kept in the database though and can be reenabled later.
+      @param isEnabled false to stop showing this notebook.
+    */
+    void setIsEnabled(bool isEnabled);
 
     /**
       Returns true if the notebook is never going to be saved; false otherwise.

--- a/src/sqliteformat.cpp
+++ b/src/sqliteformat.cpp
@@ -266,6 +266,7 @@ bool SqliteFormat::modifyCalendars(const Notebook &notebook,
         flags |= notebook.isVisible() ? SqliteFormat::Visible : 0;
         flags |= notebook.isRunTimeOnly() ? SqliteFormat::RunTimeOnly : 0;
         flags |= notebook.isShareable() ? SqliteFormat::Shareable : 0;
+        flags |= notebook.isEnabled() ? 0 : SqliteFormat::Disabled;
         SL3_bind_text(stmt, index, name, name.length(), SQLITE_STATIC);
         SL3_bind_text(stmt, index, description, description.length(), SQLITE_STATIC);
         SL3_bind_text(stmt, index, color, color.length(), SQLITE_STATIC);
@@ -1368,6 +1369,7 @@ Notebook::Ptr SqliteFormat::selectCalendars(sqlite3_stmt *stmt, bool *isDefault)
         notebook->setIsVisible(flags & SqliteFormat::Visible);
         notebook->setRunTimeOnly(flags & SqliteFormat::RunTimeOnly);
         notebook->setIsShareable(flags & SqliteFormat::Shareable);
+        notebook->setIsEnabled(!(flags & SqliteFormat::Disabled));
         notebook->setPluginName(plugin);
         notebook->setAccount(account);
         notebook->setAttachmentSize(attachmentSize);

--- a/src/sqliteformat.h
+++ b/src/sqliteformat.h
@@ -79,7 +79,8 @@ public:
         Visible       = (1 << 7),
         RunTimeOnly   = (1 << 8),
         Default       = (1 << 9),
-        Shareable     = (1 << 10)
+        Shareable     = (1 << 10),
+        Disabled      = (1 << 11)
     };
 
     SqliteFormat(sqlite3 *database);


### PR DESCRIPTION
This allows to differentiate the visibility property that is user defined from the availability of given notebooks, based on external factors like account being enabled or not.

@pvuorela, this is a work in progress. Basically, I think this part in mkcal is ready, but I'm slowly updating the related repos. And I still keep it as a draft since I've mainly not tested thoroughly yet. But you can see it as a proposition to continue the discussion from nemo-qml-plugin-calendar.