### PR TITLE
Avoid qtgui dependency

### DIFF
--- a/plugins/defaultinvitationplugin/defaultinvitationplugin.cpp
+++ b/plugins/defaultinvitationplugin/defaultinvitationplugin.cpp
@@ -34,10 +34,12 @@ const QString name("DefaultInvitationPlugin");
 class DefaultInvitationPlugin::Private
 {
 public:
-    Private() : mStore(0), mDefaultAccount(0), mInit(false),
-        mErrorCode(ServiceInterface::ErrorOk)
+    Private()
+        : mStore(nullptr), mDefaultAccount(0), mInit(false),
+          mErrorCode(ServiceInterface::ErrorOk)
     {
     }
+
     ~Private()
     {
         uninit();
@@ -64,7 +66,7 @@ public:
 
     void uninit()
     {
-        mStore = 0;
+        mStore = nullptr;
         delete mDefaultAccount;
         mDefaultAccount = 0;
         mInit = false;
@@ -392,7 +394,6 @@ QString DefaultInvitationPlugin::DefaultInvitationPlugin::serviceName() const
     d->mErrorCode = ServiceInterface::ErrorOk;
     return name;
 }
-
 
 QString DefaultInvitationPlugin::defaultNotebook() const
 {

--- a/rpm/mkcal-qt5.spec
+++ b/rpm/mkcal-qt5.spec
@@ -12,7 +12,6 @@ Requires(postun): /sbin/ldconfig
 BuildRequires:  cmake
 BuildRequires:  extra-cmake-modules >= 5.75.0
 BuildRequires:  pkgconfig(Qt5Core)
-BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(KF5CalendarCore)
 BuildRequires:  pkgconfig(sqlite3)

--- a/src/servicehandler.cpp
+++ b/src/servicehandler.cpp
@@ -21,21 +21,23 @@ using namespace KCalendarCore;
 class ServiceHandlerPrivate
 {
 public:
+    ServiceHandlerPrivate();
+
+    void loadPlugins();
+    InvitationHandlerInterface* invitationPlugin(const QString &pluginName);
+
     QHash<QString, InvitationHandlerInterface *> mPlugins;
     QHash<QString, ServiceInterface *> mServices;
 
     bool mLoaded;
     int mDownloadId;
     ServiceHandler::ErrorCode mError;
-
-    void loadPlugins();
-    InvitationHandlerInterface* invitationPlugin(const QString &pluginName);
-
-    ServiceHandlerPrivate();
 };
 
-ServiceHandlerPrivate::ServiceHandlerPrivate() : mLoaded(false), mDownloadId(0),
-    mError(ServiceHandler::ErrorOk)
+ServiceHandlerPrivate::ServiceHandlerPrivate()
+    : mLoaded(false)
+    , mDownloadId(0)
+    , mError(ServiceHandler::ErrorOk)
 {
 }
 


### PR DESCRIPTION
Long time unnecessary and was removed from cmakelists in the just merged qt6 support PR.