### PR TITLE
fix: adapt to QDateTime changes in newer Qt versions

### DIFF
--- a/src/alarmhandler.cpp
+++ b/src/alarmhandler.cpp
@@ -184,7 +184,11 @@ static void addAlarms(Timed::Event::List *events,
         Timed::Event &e = events->append();
         e.setUserModeFlag();
         e.setMaximalTimeoutSnoozeCounter(2);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 8, 0)
+        e.setTicker(alarmTime.toUTC().toSecsSinceEpoch());
+#else
         e.setTicker(alarmTime.toUTC().toTime_t());
+#endif
         // The code'll crash (=exception) iff the content is empty. So
         // we have to check here.
         QString s;
@@ -202,8 +206,12 @@ static void addAlarms(Timed::Event::List *events,
         Q_ASSERT(!incidence.uid().isEmpty());
         e.setAttribute("uid", incidence.uid());
 #ifndef QT_NO_DEBUG_OUTPUT //Helps debuggin
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+        e.setAttribute("alarmtime", alarmTime.toOffsetFromUtc(0).toString(Qt::ISODate));
+#else
         e.setAttribute("alarmtime", alarmTime.toTimeSpec(Qt::OffsetFromUTC).toString(Qt::ISODate));
 #endif
+#endif // QT_NO_DEBUG_OUTPUT
         if (!incidence.location().isEmpty()) {
             e.setAttribute("location", incidence.location());
         }
@@ -222,7 +230,11 @@ static void addAlarms(Timed::Event::List *events,
             const Todo *todo = static_cast<const Todo*>(&incidence);
 
             if (todo->hasDueDate()) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+                e.setAttribute("time", todo->dtDue(true).toOffsetFromUtc(0).toString(Qt::ISODate));
+#else
                 e.setAttribute("time", todo->dtDue(true).toTimeSpec(Qt::OffsetFromUTC).toString(Qt::ISODate));
+#endif
             }
             e.setAttribute("type", "todo");
         } else if (incidence.dtStart().isValid()) {
@@ -234,11 +246,19 @@ static void addAlarms(Timed::Event::List *events,
             } else {
                 eventStart = incidence.dtStart();
             }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+            e.setAttribute("time", eventStart.toOffsetFromUtc(0).toString(Qt::ISODate));
+            e.setAttribute("startDate", eventStart.toOffsetFromUtc(0).toString(Qt::ISODate));
+            if (incidence.endDateForStart(eventStart).isValid()) {
+                e.setAttribute("endDate", incidence.endDateForStart(eventStart).toOffsetFromUtc(0).toString(Qt::ISODate));
+            }
+#else
             e.setAttribute("time", eventStart.toTimeSpec(Qt::OffsetFromUTC).toString(Qt::ISODate));
             e.setAttribute("startDate", eventStart.toTimeSpec(Qt::OffsetFromUTC).toString(Qt::ISODate));
             if (incidence.endDateForStart(eventStart).isValid()) {
                 e.setAttribute("endDate", incidence.endDateForStart(eventStart).toTimeSpec(Qt::OffsetFromUTC).toString(Qt::ISODate));
             }
+#endif
             e.setAttribute("type", "event");
         }
 


### PR DESCRIPTION
Not sure how this got missed, the earlier Qt6 PR seemed to compile for me. However `toTime_t()` is not available in Qt6 and thus fails compilation. The other `toTimeSpec()` changes are to prevent deprecation warnings.