### PR TITLE
[mkcal] Fix tst_perf not working with kf6 CalendarCore.

### DIFF
--- a/tests/tst_perf.cpp
+++ b/tests/tst_perf.cpp
@@ -35,19 +35,14 @@ static const int N_EVENTS = 200;
 
 void tst_perf::initTestCase()
 {
-    QString dbFile = QString::fromLatin1(qgetenv("MKCAL_STORAGEDB"));
-    if (dbFile.isEmpty()) {
+    if (qgetenv("MKCAL_STORAGEDB").isEmpty()) {
         db = new QTemporaryFile();
-        db->open();
-        dbFile = db->fileName();
+        QVERIFY(db->open());
     }
-    ExtendedCalendar::Ptr cal(new ExtendedCalendar(QTimeZone::systemTimeZone()));
-    m_storage = ExtendedStorage::Ptr(new SqliteStorage(cal, dbFile, true));
 }
 
 void tst_perf::cleanupTestCase()
 {
-    m_storage.clear();
     if (db)
         QFile::remove(db->fileName() + ".changed");
     delete db;
@@ -55,15 +50,18 @@ void tst_perf::cleanupTestCase()
 
 void tst_perf::init()
 {
-    QVERIFY(m_storage->calendar()->rawEvents().isEmpty());
+    ExtendedCalendar::Ptr cal(new ExtendedCalendar(QTimeZone::systemTimeZone()));
+    if (db)
+        m_storage = ExtendedStorage::Ptr(new SqliteStorage(cal, db->fileName(), true));
+    else
+        m_storage = ExtendedStorage::Ptr(new SqliteStorage(cal, QString::fromLatin1(qgetenv("MKCAL_STORAGEDB")), true));
     QVERIFY(m_storage->open());
 }
 
 void tst_perf::cleanup()
 {
     QVERIFY(m_storage->close());
-    m_storage->calendar()->close();
-    QVERIFY(m_storage->calendar()->rawEvents().isEmpty());
+    m_storage.clear();
 }
 
 void tst_perf::tst_save()


### PR DESCRIPTION
The Calendar::close() virtual method has been removed from KF6. As a consequence, the overloading ExtendedCalendar::close() method is not overloading anymore and not calling the parent class method anymore.

I don't see any way to clear a MemoryCalendar anymore, so I rework the test to recreate the calendar (and thus the storage) for each test, ensuring that the calendar is empty not to affect the performence
measurements.

@pvuorela , this should fix the test failing when compiled in a Qt6 environment you mentioned by email.