### PR TITLE
[mkcal] Fix a failing test on i386.

### DIFF
--- a/tests/tst_storage.cpp
+++ b/tests/tst_storage.cpp
@@ -484,7 +484,9 @@ void tst_storage::tst_recurrenceExpansion()
         = rawExpandedIncidences(*m_calendar, QDateTime(QDate(2019, 11, 05), QTime(0, 0)),
                                 QDateTime(QDate(2019, 11, 18), QTime(23, 59, 59)));
 
-    const KCalendarCore::DateTimeList timesInInterval = event->recurrence()->timesInInterval(
+    KCalendarCore::Incidence::Ptr inc = m_calendar->incidence(event->uid());
+    QVERIFY(inc);
+    const KCalendarCore::DateTimeList timesInInterval = inc->recurrence()->timesInInterval(
             QDateTime::fromString(QStringLiteral("2019-11-05T00:00:00Z"), Qt::ISODate),
             QDateTime::fromString(intervalEnd, Qt::ISODate));
 


### PR DESCRIPTION
The occurrences of the recurrence were not properly computed on i386 for the following reasons:
- on i386, QDateTime cannot store short description because there is no enough bits, and there are different code paths for short description and others that force the recalculation of the UTC offset for LocalTime spec.
- the timesInInterval() was using the recurrence() of the event which was created in UTC timezone, while used in the Brisbane timezone. The local time of the starting day of the recurrence was then set to 2:00 UTC, while it was compared with 2:00 in Brisbane, failing the matching.

Close #78 